### PR TITLE
ci: Migration from ci-runner to matterlabs-ci-runner

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build-push-image:
     name: Build and push Docker image
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [matterlabs-ci-runner]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Migration from deprecated self-hosted, ci-runners to matterlabs-ci-runners

We are moving from deprecated runners to stable.