### PR TITLE
refactor: Minor `protobuf_build` chores

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -2844,6 +2844,7 @@ dependencies = [
  "heck",
  "once_cell",
  "prettyplease",
+ "proc-macro2",
  "prost",
  "prost-build",
  "prost-reflect",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -53,6 +53,7 @@ hex = "0.4.3"
 im = "15.1.0"
 once_cell = "1.17.1"
 pin-project = "1.1.0"
+proc-macro2 = "1.0.66"
 prost = "0.12.0"
 prost-build = "0.12.0"
 prost-reflect = { version = "0.12.0", features = ["serde"] }

--- a/node/libs/protobuf/build.rs
+++ b/node/libs/protobuf/build.rs
@@ -4,7 +4,7 @@ fn main() {
         input_root: "src/proto".into(),
         proto_root: "zksync".into(),
         dependencies: vec![],
-        protobuf_crate: "crate".into(),
+        protobuf_crate: "crate".parse().expect("protobuf_crate"),
     }
     .generate()
     .expect("generate(std)");
@@ -13,7 +13,7 @@ fn main() {
         input_root: "src/tests/proto".into(),
         proto_root: "zksync/protobuf/tests".into(),
         dependencies: vec![],
-        protobuf_crate: "crate".into(),
+        protobuf_crate: "crate".parse().expect("protobuf_crate"),
     }
     .generate()
     .expect("generate(test)");
@@ -22,7 +22,7 @@ fn main() {
         input_root: "src/bin/conformance_test/proto".into(),
         proto_root: "zksync/protobuf/conformance_test".into(),
         dependencies: vec![],
-        protobuf_crate: "::zksync_protobuf".into(),
+        protobuf_crate: "::zksync_protobuf".parse().expect("protobuf_crate"),
     }
     .generate()
     .expect("generate(conformance)");

--- a/node/libs/protobuf_build/Cargo.toml
+++ b/node/libs/protobuf_build/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 heck.workspace = true
 once_cell.workspace = true
 prettyplease.workspace = true
+proc-macro2.workspace = true
 prost.workspace = true
 prost-build.workspace = true
 prost-types.workspace = true

--- a/node/libs/protobuf_build/src/syntax.rs
+++ b/node/libs/protobuf_build/src/syntax.rs
@@ -83,9 +83,10 @@ impl ProtoPath {
                 .join(path.strip_prefix(&input_root.abs()?).unwrap()),
         ))
     }
+}
 
-    /// Converts ProtoPath to Path.
-    pub(super) fn to_path(&self) -> &Path {
+impl AsRef<Path> for ProtoPath {
+    fn as_ref(&self) -> &Path {
         &self.0
     }
 }

--- a/node/libs/schema/build.rs
+++ b/node/libs/schema/build.rs
@@ -4,10 +4,10 @@ fn main() {
         input_root: "proto".into(),
         proto_root: "zksync/schema".into(),
         dependencies: vec![(
-            "::zksync_protobuf::proto".into(),
+            "::zksync_protobuf::proto".parse().expect("dependency_path"),
             &zksync_protobuf::proto::DESCRIPTOR,
         )],
-        protobuf_crate: "::zksync_protobuf".into(),
+        protobuf_crate: "::zksync_protobuf".parse().expect("protobuf_crate"),
     }
     .generate()
     .expect("generate()");


### PR DESCRIPTION
# What ❔

Performs minor cleanup for the protobuf_buildcrate, such as using more intelligent local variable names and relying more on `syn` types.

## Why ❔

Improves maintainability.