### PR TITLE
feat: Validate genesis block in executor config

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "serde",
+ "thiserror",
  "tracing",
  "zksync_concurrency",
  "zksync_consensus_crypto",

--- a/node/actors/executor/src/config/mod.rs
+++ b/node/actors/executor/src/config/mod.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     net,
 };
+use zksync_consensus_bft::misc::consensus_threshold;
 use zksync_consensus_crypto::{read_required_text, Text, TextFmt};
 use zksync_consensus_network::{consensus, gossip};
 use zksync_consensus_roles::{node, validator};
@@ -137,6 +138,16 @@ pub struct ExecutorConfig {
     /// Static specification of validators for Proof of Authority. Should be deprecated once we move
     /// to Proof of Stake.
     pub validators: validator::ValidatorSet,
+}
+
+impl ExecutorConfig {
+    /// Validates internal consistency of this config.
+    pub(crate) fn validate(&self) -> anyhow::Result<()> {
+        let consensus_threshold = consensus_threshold(self.validators.len());
+        self.genesis_block
+            .validate(&self.validators, consensus_threshold)?;
+        Ok(())
+    }
 }
 
 impl ProtoFmt for ExecutorConfig {

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -61,6 +61,7 @@ impl<S: WriteBlockStore + 'static> Executor<S> {
         node_key: node::SecretKey,
         storage: Arc<S>,
     ) -> anyhow::Result<Self> {
+        node_config.validate()?;
         anyhow::ensure!(
             node_config.gossip.key == node_key.public(),
             "config.gossip.key = {:?} doesn't match the secret key {:?}",

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -2,12 +2,12 @@
 
 use crate::io::Dispatcher;
 use anyhow::Context as _;
-use std::sync::Arc;
+use std::{any, sync::Arc};
 use zksync_concurrency::{ctx, net, scope};
 use zksync_consensus_bft::{misc::consensus_threshold, Consensus};
 use zksync_consensus_network as network;
 use zksync_consensus_roles::{node, validator};
-use zksync_consensus_storage::{ReplicaStateStore, ReplicaStore, WriteBlockStore};
+use zksync_consensus_storage::{BlockStore, ReplicaStateStore, ReplicaStore, WriteBlockStore};
 use zksync_consensus_sync_blocks::SyncBlocks;
 use zksync_consensus_utils::pipe;
 
@@ -56,7 +56,8 @@ pub struct Executor<S> {
 
 impl<S: WriteBlockStore + 'static> Executor<S> {
     /// Creates a new executor with the specified parameters.
-    pub fn new(
+    pub async fn new(
+        ctx: &ctx::Ctx,
         node_config: ExecutorConfig,
         node_key: node::SecretKey,
         storage: Arc<S>,
@@ -67,6 +68,16 @@ impl<S: WriteBlockStore + 'static> Executor<S> {
             "config.gossip.key = {:?} doesn't match the secret key {:?}",
             node_config.gossip.key,
             node_key
+        );
+
+        // While justifications may differ among nodes for an arbitrary block, we assume that
+        // the genesis block has a hardcoded justification.
+        let first_block = storage.first_block(ctx).await.context("first_block")?;
+        anyhow::ensure!(
+            first_block == node_config.genesis_block,
+            "First stored block {first_block:?} in `{}` is not equal to the configured genesis block {:?}",
+            any::type_name::<S>(),
+            node_config.genesis_block
         );
 
         Ok(Self {

--- a/node/actors/sync_blocks/src/peers/tests/fakes.rs
+++ b/node/actors/sync_blocks/src/peers/tests/fakes.rs
@@ -51,13 +51,7 @@ async fn processing_invalid_blocks() {
     let err = peer_states
         .validate_block(BlockNumber(1), invalid_block)
         .unwrap_err();
-    assert_matches!(
-        err,
-        BlockValidationError::NumberMismatch {
-            requested: BlockNumber(1),
-            got: BlockNumber(0),
-        }
-    );
+    assert_matches!(err, BlockValidationError::Other(_));
 
     let mut invalid_block = test_validators.final_blocks[1].clone();
     invalid_block.justification = test_validators.final_blocks[0].justification.clone();

--- a/node/libs/roles/Cargo.toml
+++ b/node/libs/roles/Cargo.toml
@@ -20,6 +20,7 @@ hex.workspace = true
 prost.workspace = true
 rand.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [build-dependencies]

--- a/node/libs/roles/src/validator/messages/block.rs
+++ b/node/libs/roles/src/validator/messages/block.rs
@@ -8,8 +8,18 @@ use zksync_consensus_crypto::{keccak256::Keccak256, ByteFmt, Text, TextFmt};
 /// (except for imposing a size limit for the payload). Proposing a payload
 /// for a new block and interpreting the payload of the finalized blocks
 /// should be implemented for the specific application of the consensus algorithm.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Payload(pub Vec<u8>);
+
+impl fmt::Debug for Payload {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Payload")
+            .field("len", &self.0.len())
+            .field("hash", &self.hash())
+            .finish()
+    }
+}
 
 /// Hash of the Payload.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/node/libs/roles/src/validator/mod.rs
+++ b/node/libs/roles/src/validator/mod.rs
@@ -8,5 +8,4 @@ mod keys;
 mod messages;
 pub mod testonly;
 
-pub use keys::*;
-pub use messages::*;
+pub use self::{keys::*, messages::*};

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -106,7 +106,8 @@ async fn main() -> anyhow::Result<()> {
         Path::new("./database"),
     );
     let storage = Arc::new(storage.await.context("RocksdbStorage::new()")?);
-    let mut executor = Executor::new(configs.executor, configs.node_key, storage.clone())
+    let mut executor = Executor::new(ctx, configs.executor, configs.node_key, storage.clone())
+        .await
         .context("Executor::new()")?;
     if let Some((consensus_config, validator_key)) = configs.consensus {
         executor


### PR DESCRIPTION
## What ❔

Validate genesis block self-consistency and correspondence to storage when an `Executor` is created.

## Why ❔

Allows not to accidentally break a node due to misconfiguration.