### PR TITLE
feat: Allow configuring protocol version

### DIFF
--- a/node/actors/bft/src/inner.rs
+++ b/node/actors/bft/src/inner.rs
@@ -18,6 +18,8 @@ pub(crate) struct ConsensusInner {
     pub(crate) secret_key: validator::SecretKey,
     /// A vector of public keys for all the validators in the network.
     pub(crate) validator_set: validator::ValidatorSet,
+    /// Current protocol version for the consensus messages.
+    pub(crate) protocol_version: validator::ProtocolVersion,
 }
 
 impl ConsensusInner {

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -148,7 +148,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderCommit(
                     validator::LeaderCommit {
-                        protocol_version: validator::CURRENT_VERSION,
+                        protocol_version: self.protocol_version,
                         justification,
                     },
                 )),

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -148,7 +148,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderCommit(
                     validator::LeaderCommit {
-                        protocol_version: self.protocol_version,
+                        protocol_version: consensus.protocol_version,
                         justification,
                     },
                 )),

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -214,7 +214,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderPrepare(
                     validator::LeaderPrepare {
-                        protocol_version: self.protocol_version,
+                        protocol_version: consensus.protocol_version,
                         view: self.view,
                         proposal,
                         proposal_payload: payload,

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -214,7 +214,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderPrepare(
                     validator::LeaderPrepare {
-                        protocol_version: validator::CURRENT_VERSION,
+                        protocol_version: self.protocol_version,
                         view: self.view,
                         proposal,
                         proposal_payload: payload,

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -12,8 +12,6 @@ use zksync_consensus_roles::validator;
 /// those messages. When participating in consensus we are not the leader most of the time.
 #[derive(Debug)]
 pub(crate) struct StateMachine {
-    /// Current protocol version for the consensus messages.
-    pub(crate) protocol_version: validator::ProtocolVersion,
     /// The current view number. This might not match the replica's view number, we only have this here
     /// to make the leader advance monotonically in time and stop it from accepting messages from the past.
     pub(crate) view: validator::ViewNumber,
@@ -39,9 +37,8 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct.
     #[instrument(level = "trace", ret)]
-    pub fn new(ctx: &ctx::Ctx, protocol_version: validator::ProtocolVersion) -> Self {
+    pub fn new(ctx: &ctx::Ctx) -> Self {
         StateMachine {
-            protocol_version,
             view: validator::ViewNumber(0),
             phase: validator::Phase::Prepare,
             phase_start: ctx.now(),

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -12,6 +12,8 @@ use zksync_consensus_roles::validator;
 /// those messages. When participating in consensus we are not the leader most of the time.
 #[derive(Debug)]
 pub(crate) struct StateMachine {
+    /// Current protocol version for the consensus messages.
+    pub(crate) protocol_version: validator::ProtocolVersion,
     /// The current view number. This might not match the replica's view number, we only have this here
     /// to make the leader advance monotonically in time and stop it from accepting messages from the past.
     pub(crate) view: validator::ViewNumber,
@@ -37,8 +39,9 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct.
     #[instrument(level = "trace", ret)]
-    pub fn new(ctx: &ctx::Ctx) -> Self {
+    pub fn new(ctx: &ctx::Ctx, protocol_version: validator::ProtocolVersion) -> Self {
         StateMachine {
+            protocol_version,
             view: validator::ViewNumber(0),
             phase: validator::Phase::Prepare,
             phase_start: ctx.now(),

--- a/node/actors/bft/src/leader/tests.rs
+++ b/node/actors/bft/src/leader/tests.rs
@@ -10,7 +10,11 @@ async fn replica_commit() {
     let rng = &mut StdRng::seed_from_u64(6516565651);
 
     let keys: Vec<_> = (0..1).map(|_| rng.gen()).collect();
-    let (genesis, val_set) = testonly::make_genesis(&keys, validator::Payload(vec![]));
+    let (genesis, val_set) = testonly::make_genesis(
+        &keys,
+        validator::ProtocolVersion::EARLIEST,
+        validator::Payload(vec![]),
+    );
     let (mut consensus, _) = testonly::make_consensus(ctx, &keys[0], &val_set, &genesis).await;
 
     consensus.leader.view = validator::ViewNumber(3);
@@ -22,7 +26,7 @@ async fn replica_commit() {
             .secret_key
             .sign_msg(validator::ConsensusMsg::ReplicaCommit(
                 validator::ReplicaCommit {
-                    protocol_version: validator::CURRENT_VERSION,
+                    protocol_version: validator::ProtocolVersion::EARLIEST,
                     view: consensus.leader.view,
                     proposal: rng.gen(),
                 },

--- a/node/actors/bft/src/lib.rs
+++ b/node/actors/bft/src/lib.rs
@@ -61,9 +61,10 @@ impl Consensus {
                 pipe,
                 secret_key,
                 validator_set,
+                protocol_version,
             },
-            replica: replica::StateMachine::new(ctx, storage, protocol_version).await?,
-            leader: leader::StateMachine::new(ctx, protocol_version),
+            replica: replica::StateMachine::new(ctx, storage).await?,
+            leader: leader::StateMachine::new(ctx),
         })
     }
 
@@ -100,10 +101,10 @@ impl Consensus {
 
             match input {
                 Some(InputMessage::Network(req)) => {
-                    if req.msg.msg.protocol_version() != self.replica.protocol_version {
+                    if req.msg.msg.protocol_version() != self.inner.protocol_version {
                         tracing::warn!(
                             "bad protocol version (expected: {:?}, received: {:?})",
-                            self.replica.protocol_version,
+                            self.inner.protocol_version,
                             req.msg.msg.protocol_version()
                         );
                         continue;

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -253,7 +253,7 @@ impl StateMachine {
 
         // Create our commit vote.
         let commit_vote = validator::ReplicaCommit {
-            protocol_version: validator::CURRENT_VERSION,
+            protocol_version: self.protocol_version,
             view,
             proposal: message.proposal,
         };

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -253,7 +253,7 @@ impl StateMachine {
 
         // Create our commit vote.
         let commit_vote = validator::ReplicaCommit {
-            protocol_version: self.protocol_version,
+            protocol_version: consensus.protocol_version,
             view,
             proposal: message.proposal,
         };

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -35,7 +35,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                     validator::ReplicaPrepare {
-                        protocol_version: validator::CURRENT_VERSION,
+                        protocol_version: self.protocol_version,
                         view: next_view,
                         high_vote: self.high_vote,
                         high_qc: self.high_qc.clone(),

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -35,7 +35,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                     validator::ReplicaPrepare {
-                        protocol_version: self.protocol_version,
+                        protocol_version: consensus.protocol_version,
                         view: next_view,
                         high_vote: self.high_vote,
                         high_qc: self.high_qc.clone(),

--- a/node/actors/bft/src/replica/state_machine.rs
+++ b/node/actors/bft/src/replica/state_machine.rs
@@ -11,8 +11,6 @@ use zksync_consensus_storage::ReplicaStore;
 /// for validating and voting on blocks. When participating in consensus we are always a replica.
 #[derive(Debug)]
 pub(crate) struct StateMachine {
-    /// Current protocol version for the consensus messages.
-    pub(crate) protocol_version: validator::ProtocolVersion,
     /// The current view number.
     pub(crate) view: validator::ViewNumber,
     /// The current phase.
@@ -34,11 +32,7 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct. We try to recover a past state from the storage module,
     /// otherwise we initialize the state machine with whatever head block we have.
-    pub(crate) async fn new(
-        ctx: &ctx::Ctx,
-        storage: ReplicaStore,
-        protocol_version: validator::ProtocolVersion,
-    ) -> anyhow::Result<Self> {
+    pub(crate) async fn new(ctx: &ctx::Ctx, storage: ReplicaStore) -> anyhow::Result<Self> {
         let backup = storage.replica_state(ctx).await?;
         let mut block_proposal_cache: BTreeMap<_, HashMap<_, _>> = BTreeMap::new();
         for proposal in backup.proposals {
@@ -49,7 +43,6 @@ impl StateMachine {
         }
 
         Ok(Self {
-            protocol_version,
             view: backup.view,
             phase: backup.phase,
             high_vote: backup.high_vote,

--- a/node/actors/bft/src/replica/state_machine.rs
+++ b/node/actors/bft/src/replica/state_machine.rs
@@ -11,6 +11,8 @@ use zksync_consensus_storage::ReplicaStore;
 /// for validating and voting on blocks. When participating in consensus we are always a replica.
 #[derive(Debug)]
 pub(crate) struct StateMachine {
+    /// Current protocol version for the consensus messages.
+    pub(crate) protocol_version: validator::ProtocolVersion,
     /// The current view number.
     pub(crate) view: validator::ViewNumber,
     /// The current phase.
@@ -32,7 +34,11 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct. We try to recover a past state from the storage module,
     /// otherwise we initialize the state machine with whatever head block we have.
-    pub(crate) async fn new(ctx: &ctx::Ctx, storage: ReplicaStore) -> anyhow::Result<Self> {
+    pub(crate) async fn new(
+        ctx: &ctx::Ctx,
+        storage: ReplicaStore,
+        protocol_version: validator::ProtocolVersion,
+    ) -> anyhow::Result<Self> {
         let backup = storage.replica_state(ctx).await?;
         let mut block_proposal_cache: BTreeMap<_, HashMap<_, _>> = BTreeMap::new();
         for proposal in backup.proposals {
@@ -43,6 +49,7 @@ impl StateMachine {
         }
 
         Ok(Self {
+            protocol_version,
             view: backup.view,
             phase: backup.phase,
             high_vote: backup.high_vote,

--- a/node/actors/bft/src/replica/tests.rs
+++ b/node/actors/bft/src/replica/tests.rs
@@ -11,7 +11,11 @@ async fn start_new_view_not_leader() {
     let rng = &mut ctx.rng();
 
     let keys: Vec<_> = (0..4).map(|_| rng.gen()).collect();
-    let (genesis, val_set) = testonly::make_genesis(&keys, validator::Payload(vec![]));
+    let (genesis, val_set) = testonly::make_genesis(
+        &keys,
+        validator::ProtocolVersion::EARLIEST,
+        validator::Payload(vec![]),
+    );
     let (mut consensus, mut pipe) =
         testonly::make_consensus(ctx, &keys[0], &val_set, &genesis).await;
     // TODO: this test assumes a specific implementation of the leader schedule.
@@ -40,7 +44,7 @@ async fn start_new_view_not_leader() {
             .secret_key
             .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                 validator::ReplicaPrepare {
-                    protocol_version: validator::CURRENT_VERSION,
+                    protocol_version: validator::ProtocolVersion::EARLIEST,
                     view: consensus.replica.view,
                     high_vote: consensus.replica.high_vote,
                     high_qc: consensus.replica.high_qc.clone(),

--- a/node/actors/bft/src/testonly/make.rs
+++ b/node/actors/bft/src/testonly/make.rs
@@ -25,6 +25,7 @@ pub async fn make_consensus(
     let consensus = Consensus::new(
         ctx,
         consensus_pipe,
+        genesis_block.justification.message.protocol_version,
         key.clone(),
         validator_set.clone(),
         ReplicaStore::from_store(Arc::new(storage)),
@@ -39,6 +40,7 @@ pub async fn make_consensus(
 /// and a validator set for the chain.
 pub fn make_genesis(
     keys: &[validator::SecretKey],
+    protocol_version: validator::ProtocolVersion,
     payload: validator::Payload,
 ) -> (validator::FinalBlock, validator::ValidatorSet) {
     let header = validator::BlockHeader::genesis(payload.hash());
@@ -47,7 +49,7 @@ pub fn make_genesis(
         .iter()
         .map(|sk| {
             sk.sign_msg(validator::ReplicaCommit {
-                protocol_version: validator::CURRENT_VERSION,
+                protocol_version,
                 view: validator::ViewNumber(0),
                 proposal: header,
             })

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -32,7 +32,11 @@ impl Test {
             .iter()
             .map(|node| node.consensus_config().key.clone())
             .collect();
-        let (genesis_block, _) = testonly::make_genesis(&keys, validator::Payload(vec![]));
+        let (genesis_block, _) = testonly::make_genesis(
+            &keys,
+            validator::ProtocolVersion::EARLIEST,
+            validator::Payload(vec![]),
+        );
         let nodes: Vec<_> = nodes
             .into_iter()
             .enumerate()
@@ -102,6 +106,7 @@ async fn run_nodes(ctx: &ctx::Ctx, network: Network, nodes: &[Node]) -> anyhow::
                     let consensus = Consensus::new(
                         ctx,
                         consensus_actor_pipe,
+                        validator::ProtocolVersion::EARLIEST,
                         node.net.consensus_config().key.clone(),
                         validator_set,
                         storage,

--- a/node/actors/executor/src/config/mod.rs
+++ b/node/actors/executor/src/config/mod.rs
@@ -31,11 +31,12 @@ impl ProtoFmt for ConsensusConfig {
     type Proto = proto::ConsensusConfig;
 
     fn read(proto: &Self::Proto) -> anyhow::Result<Self> {
-        let protocol_version = proto.protocol_version.context("protocol_version")?;
         Ok(Self {
             key: read_required_text(&proto.key).context("key")?,
             public_addr: read_required_text(&proto.public_addr).context("public_addr")?,
-            protocol_version: validator::ProtocolVersion::try_from(protocol_version)
+            protocol_version: required(&proto.protocol_version)
+                .copied()
+                .and_then(validator::ProtocolVersion::try_from)
                 .context("protocol_version")?,
         })
     }

--- a/node/actors/executor/src/config/proto/mod.proto
+++ b/node/actors/executor/src/config/proto/mod.proto
@@ -48,6 +48,8 @@ message NodeAddr {
 message ConsensusConfig {
   optional string key = 1; // [required] ValidatorPublicKey
   optional string public_addr = 2; // [required] IpAddr
+  // Currently used protocol version for consensus messages.
+  optional uint32 protocol_version = 3;
 }
 
 // Config of the gossip network.

--- a/node/actors/executor/src/config/proto/mod.proto
+++ b/node/actors/executor/src/config/proto/mod.proto
@@ -49,7 +49,7 @@ message ConsensusConfig {
   optional string key = 1; // [required] ValidatorPublicKey
   optional string public_addr = 2; // [required] IpAddr
   // Currently used protocol version for consensus messages.
-  optional uint32 protocol_version = 3;
+  optional uint32 protocol_version = 3; // [required]
 }
 
 // Config of the gossip network.

--- a/node/actors/executor/src/config/tests.rs
+++ b/node/actors/executor/src/config/tests.rs
@@ -16,6 +16,7 @@ impl Distribution<ConsensusConfig> for Standard {
         ConsensusConfig {
             key: rng.gen::<validator::SecretKey>().public(),
             public_addr: make_addr(rng),
+            protocol_version: validator::ProtocolVersion::EARLIEST,
         }
     }
 }

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -171,6 +171,7 @@ impl<S: WriteBlockStore + 'static> Executor<S> {
             let consensus = Consensus::new(
                 ctx,
                 consensus_actor_pipe,
+                validator.config.protocol_version,
                 validator.key.clone(),
                 validator_set.clone(),
                 consensus_storage,

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -21,7 +21,7 @@ impl FullValidatorConfig {
                 payload: payload.hash(),
             };
             let commit = self.validator_key.sign_msg(validator::ReplicaCommit {
-                protocol_version: validator::CURRENT_VERSION,
+                protocol_version: validator::ProtocolVersion::EARLIEST,
                 view: validator::ViewNumber(header.number.0),
                 proposal: header,
             });
@@ -67,7 +67,11 @@ async fn executor_misconfiguration(name: &str, mutation: fn(&mut FinalBlock)) {
     let ctx = &ctx::root();
     let rng = &mut ctx.rng();
 
-    let mut validator = FullValidatorConfig::for_single_validator(rng, Payload(vec![]));
+    let mut validator = FullValidatorConfig::for_single_validator(
+        rng,
+        validator::ProtocolVersion::EARLIEST,
+        Payload(vec![]),
+    );
     let genesis_block = &mut validator.node_config.genesis_block;
     mutation(genesis_block);
     let storage = Arc::new(InMemoryStorage::new(genesis_block.clone()));
@@ -83,7 +87,11 @@ async fn genesis_block_mismatch() {
     let ctx = &ctx::root();
     let rng = &mut ctx.rng();
 
-    let validator = FullValidatorConfig::for_single_validator(rng, Payload(vec![]));
+    let validator = FullValidatorConfig::for_single_validator(
+        rng,
+        validator::ProtocolVersion::EARLIEST,
+        Payload(vec![]),
+    );
     let mut genesis_block = validator.node_config.genesis_block.clone();
     genesis_block.header.number = BlockNumber(1);
     let storage = Arc::new(InMemoryStorage::new(genesis_block.clone()));
@@ -99,7 +107,11 @@ async fn executing_single_validator() {
     let ctx = &ctx::root();
     let rng = &mut ctx.rng();
 
-    let validator = FullValidatorConfig::for_single_validator(rng, Payload(vec![]));
+    let validator = FullValidatorConfig::for_single_validator(
+        rng,
+        validator::ProtocolVersion::EARLIEST,
+        Payload(vec![]),
+    );
     let genesis_block = &validator.node_config.genesis_block;
     let storage = InMemoryStorage::new(genesis_block.clone());
     let storage = Arc::new(storage);
@@ -124,7 +136,11 @@ async fn executing_validator_and_full_node() {
     let ctx = &ctx::test_root(&ctx::AffineClock::new(20.0));
     let rng = &mut ctx.rng();
 
-    let mut validator = FullValidatorConfig::for_single_validator(rng, Payload(vec![]));
+    let mut validator = FullValidatorConfig::for_single_validator(
+        rng,
+        validator::ProtocolVersion::EARLIEST,
+        Payload(vec![]),
+    );
     let full_node = validator.connect_full_node(rng);
 
     let genesis_block = &validator.node_config.genesis_block;
@@ -166,7 +182,11 @@ async fn syncing_full_node_from_snapshot(delay_block_storage: bool) {
     let ctx = &ctx::test_root(&ctx::AffineClock::new(20.0));
     let rng = &mut ctx.rng();
 
-    let mut validator = FullValidatorConfig::for_single_validator(rng, Payload(vec![]));
+    let mut validator = FullValidatorConfig::for_single_validator(
+        rng,
+        validator::ProtocolVersion::EARLIEST,
+        Payload(vec![]),
+    );
     let mut full_node = validator.connect_full_node(rng);
 
     let genesis_block = &validator.node_config.genesis_block;

--- a/node/actors/sync_blocks/src/tests/mod.rs
+++ b/node/actors/sync_blocks/src/tests/mod.rs
@@ -68,7 +68,7 @@ impl TestValidators {
 
     fn certify_block(&self, proposal: &BlockHeader) -> CommitQC {
         let message_to_sign = validator::ReplicaCommit {
-            protocol_version: validator::CURRENT_VERSION,
+            protocol_version: validator::ProtocolVersion::EARLIEST,
             view: validator::ViewNumber(proposal.number.0),
             proposal: *proposal,
         };
@@ -120,10 +120,11 @@ async fn subscribing_to_state_updates() {
 
     let ctx = &ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
-    let genesis_block = make_genesis_block(rng);
-    let block_1 = make_block(rng, &genesis_block.header);
-    let block_2 = make_block(rng, &block_1.header);
-    let block_3 = make_block(rng, &block_2.header);
+    let protocol_version = validator::ProtocolVersion::EARLIEST;
+    let genesis_block = make_genesis_block(rng, protocol_version);
+    let block_1 = make_block(rng, &genesis_block.header, protocol_version);
+    let block_2 = make_block(rng, &block_1.header, protocol_version);
+    let block_3 = make_block(rng, &block_2.header, protocol_version);
 
     let storage = InMemoryStorage::new(genesis_block.clone());
     let storage = &Arc::new(storage);
@@ -195,12 +196,13 @@ async fn getting_blocks() {
 
     let ctx = &ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
-    let genesis_block = make_genesis_block(rng);
+    let protocol_version = validator::ProtocolVersion::EARLIEST;
+    let genesis_block = make_genesis_block(rng, protocol_version);
 
     let storage = InMemoryStorage::new(genesis_block.clone());
     let storage = Arc::new(storage);
     let blocks = iter::successors(Some(genesis_block), |parent| {
-        Some(make_block(rng, &parent.header))
+        Some(make_block(rng, &parent.header, protocol_version))
     });
     let blocks: Vec<_> = blocks.take(5).collect();
     for block in &blocks {

--- a/node/libs/protobuf_build/src/lib.rs
+++ b/node/libs/protobuf_build/src/lib.rs
@@ -299,7 +299,7 @@ impl Config {
             .context("prepare_output_dir()")?;
         let output_path = output_dir.join("gen.rs");
         let descriptor_path = output_dir.join("gen.binpb");
-        fs::write(&descriptor_path, &descriptor.encode_to_vec())?;
+        fs::write(&descriptor_path, descriptor.encode_to_vec())?;
 
         if self.is_public {
             let manifest = Manifest {

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -13,13 +13,25 @@ use zksync_consensus_utils::enum_util::{BadVariantError, Variant};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProtocolVersion(pub(crate) u32);
 
-/// We use a hardcoded protocol version for now.
-/// Eventually validators should determine which version to use for which block by observing the relevant L1 contract.
-///
-/// The validator binary has to support the current and next protocol version whenever
-/// a protocol version update is needed (so that it can dynamically switch from producing
-/// blocks for version X to version X+1).
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion(0);
+impl ProtocolVersion {
+    /// Earliest protocol version.
+    pub const EARLIEST: Self = Self(0);
+
+    /// Returns the integer corresponding to this version.
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<u32> for ProtocolVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        // Currently, consensus doesn't define restrictions on the possible version. Unsupported
+        // versions are filtered out on the BFT actor level instead.
+        Ok(Self(value))
+    }
+}
 
 /// Consensus messages.
 #[allow(missing_docs)]

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -3,7 +3,7 @@ use super::{
     AggregateSignature, BlockHeader, BlockHeaderHash, BlockNumber, CommitQC, ConsensusMsg,
     FinalBlock, LeaderCommit, LeaderPrepare, Msg, MsgHash, NetAddress, Payload, PayloadHash, Phase,
     PrepareQC, ProtocolVersion, PublicKey, ReplicaCommit, ReplicaPrepare, SecretKey, Signature,
-    Signed, Signers, ValidatorSet, ViewNumber, CURRENT_VERSION,
+    Signed, Signers, ValidatorSet, ViewNumber,
 };
 use bit_vec::BitVec;
 use rand::{
@@ -16,10 +16,14 @@ use zksync_consensus_utils::enum_util::Variant;
 
 /// Constructs a CommitQC with `CommitQC.message.proposal` matching header.
 /// WARNING: it is not a fully correct CommitQC.
-pub fn make_justification<R: Rng>(rng: &mut R, header: &BlockHeader) -> CommitQC {
+pub fn make_justification<R: Rng>(
+    rng: &mut R,
+    header: &BlockHeader,
+    protocol_version: ProtocolVersion,
+) -> CommitQC {
     CommitQC {
         message: ReplicaCommit {
-            protocol_version: CURRENT_VERSION,
+            protocol_version,
             view: ViewNumber(header.number.0),
             proposal: *header,
         },
@@ -30,10 +34,10 @@ pub fn make_justification<R: Rng>(rng: &mut R, header: &BlockHeader) -> CommitQC
 
 /// Constructs a genesis block with random payload.
 /// WARNING: it is not a fully correct FinalBlock.
-pub fn make_genesis_block<R: Rng>(rng: &mut R) -> FinalBlock {
+pub fn make_genesis_block<R: Rng>(rng: &mut R, protocol_version: ProtocolVersion) -> FinalBlock {
     let payload: Payload = rng.gen();
     let header = BlockHeader::genesis(payload.hash());
-    let justification = make_justification(rng, &header);
+    let justification = make_justification(rng, &header, protocol_version);
     FinalBlock {
         header,
         payload,
@@ -43,10 +47,14 @@ pub fn make_genesis_block<R: Rng>(rng: &mut R) -> FinalBlock {
 
 /// Constructs a random block with a given parent.
 /// WARNING: this is not a fully correct FinalBlock.
-pub fn make_block<R: Rng>(rng: &mut R, parent: &BlockHeader) -> FinalBlock {
+pub fn make_block<R: Rng>(
+    rng: &mut R,
+    parent: &BlockHeader,
+    protocol_version: ProtocolVersion,
+) -> FinalBlock {
     let payload: Payload = rng.gen();
     let header = BlockHeader::new(parent, payload.hash());
-    let justification = make_justification(rng, &header);
+    let justification = make_justification(rng, &header, protocol_version);
     FinalBlock {
         header,
         payload,

--- a/node/libs/storage/src/tests/mod.rs
+++ b/node/libs/storage/src/tests/mod.rs
@@ -6,7 +6,7 @@ use std::iter;
 use test_casing::test_casing;
 use zksync_concurrency::ctx;
 use zksync_consensus_roles::validator::{
-    testonly::make_block, BlockHeader, BlockNumber, FinalBlock, Payload,
+    testonly::make_block, BlockHeader, BlockNumber, FinalBlock, Payload, ProtocolVersion,
 };
 
 #[cfg(feature = "rocksdb")]
@@ -39,7 +39,7 @@ fn genesis_block(rng: &mut impl Rng) -> FinalBlock {
 
 fn gen_blocks(rng: &mut impl Rng, genesis_block: FinalBlock, count: usize) -> Vec<FinalBlock> {
     let blocks = iter::successors(Some(genesis_block), |parent| {
-        Some(make_block(rng, &parent.header))
+        Some(make_block(rng, &parent.header, ProtocolVersion::EARLIEST))
     });
     blocks.skip(1).take(count).collect()
 }
@@ -57,7 +57,7 @@ async fn test_put_block(store_factory: &impl InitStore) {
     assert_eq!(*block_subscriber.borrow_and_update(), BlockNumber(0));
 
     // Test inserting a block with a valid parent.
-    let block_1 = make_block(rng, &genesis_block.header);
+    let block_1 = make_block(rng, &genesis_block.header, ProtocolVersion::EARLIEST);
     block_store.put_block(ctx, &block_1).await.unwrap();
 
     assert_eq!(block_store.first_block(ctx).await.unwrap(), genesis_block);
@@ -65,7 +65,7 @@ async fn test_put_block(store_factory: &impl InitStore) {
     assert_eq!(*block_subscriber.borrow_and_update(), block_1.header.number);
 
     // Test inserting a block with a valid parent that is not the genesis.
-    let block_2 = make_block(rng, &block_1.header);
+    let block_2 = make_block(rng, &block_1.header, ProtocolVersion::EARLIEST);
     block_store.put_block(ctx, &block_2).await.unwrap();
 
     assert_eq!(block_store.first_block(ctx).await.unwrap(), genesis_block);

--- a/node/libs/storage/src/tests/rocksdb.rs
+++ b/node/libs/storage/src/tests/rocksdb.rs
@@ -19,7 +19,7 @@ async fn initializing_store_twice() {
     let genesis_block = genesis_block(rng);
     let temp_dir = TempDir::new().unwrap();
     let block_store = temp_dir.init_store(ctx, &genesis_block).await;
-    let block_1 = make_block(rng, &genesis_block.header);
+    let block_1 = make_block(rng, &genesis_block.header, ProtocolVersion::EARLIEST);
     block_store.put_block(ctx, &block_1).await.unwrap();
 
     assert_eq!(block_store.first_block(ctx).await.unwrap(), genesis_block);

--- a/node/tools/src/bin/localnet_config.rs
+++ b/node/tools/src/bin/localnet_config.rs
@@ -65,9 +65,13 @@ fn main() -> anyhow::Result<()> {
     let node_keys: Vec<node::SecretKey> = (0..addrs.len()).map(|_| rng.gen()).collect();
 
     // Generate the genesis block.
+    let protocol_version = validator::ProtocolVersion::EARLIEST;
     // TODO: generating genesis block shouldn't require knowing the private keys.
-    let (genesis, validator_set) =
-        testonly::make_genesis(&validator_keys, validator::Payload(vec![]));
+    let (genesis, validator_set) = testonly::make_genesis(
+        &validator_keys,
+        protocol_version,
+        validator::Payload(vec![]),
+    );
 
     // Each node will have `gossip_peers` outbound peers.
     let nodes = addrs.len();
@@ -109,6 +113,7 @@ fn main() -> anyhow::Result<()> {
             consensus: Some(ConsensusConfig {
                 key: validator_keys[i].public(),
                 public_addr: addrs[i],
+                protocol_version,
             }),
         };
 


### PR DESCRIPTION
## What ❔

Allows configuring protocol version for consensus messages instead of hard-coding it.

## Why ❔

We intend to use the same protocol version as for the server, which makes hard-coding it not feasible for consensus–server integration.