### PR TITLE
added support for adding context to errors types containing anyhow::Error

### DIFF
--- a/node/actors/bft/src/replica/block.rs
+++ b/node/actors/bft/src/replica/block.rs
@@ -2,7 +2,7 @@ use super::StateMachine;
 use crate::inner::ConsensusInner;
 use anyhow::Context as _;
 use tracing::{info, instrument};
-use zksync_concurrency::ctx;
+use zksync_concurrency::{ctx};
 use zksync_consensus_roles::validator;
 
 impl StateMachine {
@@ -15,7 +15,7 @@ impl StateMachine {
         ctx: &ctx::Ctx,
         consensus: &ConsensusInner,
         commit_qc: &validator::CommitQC,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(),ctx::Error> {
         // TODO(gprusak): for availability of finalized blocks,
         //                replicas should be able to broadcast highest quorums without
         //                the corresponding block (same goes for synchronization).

--- a/node/actors/sync_blocks/src/lib.rs
+++ b/node/actors/sync_blocks/src/lib.rs
@@ -80,7 +80,7 @@ impl SyncBlocks {
         // rather than catching in the constituent tasks.
         result.or_else(|err| match err {
             StorageError::Canceled(_) => Ok(()), // Cancellation is not propagated as an error
-            StorageError::Database(err) => Err(err),
+            StorageError::Internal(err) => Err(err),
         })
     }
 

--- a/node/actors/sync_blocks/src/peers/tests/mod.rs
+++ b/node/actors/sync_blocks/src/peers/tests/mod.rs
@@ -124,7 +124,7 @@ async fn test_peer_states<T: Test>(test: T) {
         s.spawn_bg(async {
             peer_states.run(ctx).await.or_else(|err| match err {
                 StorageError::Canceled(_) => Ok(()), // Swallow cancellation errors after the test is finished
-                StorageError::Database(err) => Err(err),
+                StorageError::Internal(err) => Err(err),
             })
         });
         test.test(ctx, test_handles).await

--- a/node/libs/concurrency/src/lib.rs
+++ b/node/libs/concurrency/src/lib.rs
@@ -1,6 +1,7 @@
 //! Concurrency primitives.
 
 pub mod ctx;
+pub mod error;
 pub mod io;
 pub mod limiter;
 pub mod metrics;

--- a/node/libs/storage/src/in_memory.rs
+++ b/node/libs/storage/src/in_memory.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use std::{collections::BTreeMap, ops};
 use zksync_concurrency::{
     ctx,
-    sync::{self, watch, Mutex},
+    sync::{watch, Mutex},
 };
 use zksync_consensus_roles::validator::{BlockNumber, FinalBlock};
 
@@ -90,36 +90,32 @@ impl InMemoryStorage {
 
 #[async_trait]
 impl BlockStore for InMemoryStorage {
-    async fn head_block(&self, ctx: &ctx::Ctx) -> StorageResult<FinalBlock> {
-        Ok(sync::lock(ctx, &self.blocks).await?.head_block().clone())
+    async fn head_block(&self, _ctx: &ctx::Ctx) -> StorageResult<FinalBlock> {
+        Ok(self.blocks.lock().await.head_block().clone())
     }
 
-    async fn first_block(&self, ctx: &ctx::Ctx) -> StorageResult<FinalBlock> {
-        Ok(sync::lock(ctx, &self.blocks).await?.first_block().clone())
+    async fn first_block(&self, _ctx: &ctx::Ctx) -> StorageResult<FinalBlock> {
+        Ok(self.blocks.lock().await.first_block().clone())
     }
 
-    async fn last_contiguous_block_number(&self, ctx: &ctx::Ctx) -> StorageResult<BlockNumber> {
-        Ok(sync::lock(ctx, &self.blocks)
-            .await?
-            .last_contiguous_block_number)
+    async fn last_contiguous_block_number(&self, _ctx: &ctx::Ctx) -> StorageResult<BlockNumber> {
+        Ok(self.blocks.lock().await.last_contiguous_block_number)
     }
 
     async fn block(
         &self,
-        ctx: &ctx::Ctx,
+        _ctx: &ctx::Ctx,
         number: BlockNumber,
     ) -> StorageResult<Option<FinalBlock>> {
-        Ok(sync::lock(ctx, &self.blocks).await?.block(number).cloned())
+        Ok(self.blocks.lock().await.block(number).cloned())
     }
 
     async fn missing_block_numbers(
         &self,
-        ctx: &ctx::Ctx,
+        _ctx: &ctx::Ctx,
         range: ops::Range<BlockNumber>,
     ) -> StorageResult<Vec<BlockNumber>> {
-        Ok(sync::lock(ctx, &self.blocks)
-            .await?
-            .missing_block_numbers(range))
+        Ok(self.blocks.lock().await.missing_block_numbers(range))
     }
 
     fn subscribe_to_block_writes(&self) -> watch::Receiver<BlockNumber> {
@@ -129,10 +125,8 @@ impl BlockStore for InMemoryStorage {
 
 #[async_trait]
 impl WriteBlockStore for InMemoryStorage {
-    async fn put_block(&self, ctx: &ctx::Ctx, block: &FinalBlock) -> StorageResult<()> {
-        sync::lock(ctx, &self.blocks)
-            .await?
-            .put_block(block.clone());
+    async fn put_block(&self, _ctx: &ctx::Ctx, block: &FinalBlock) -> StorageResult<()> {
+        self.blocks.lock().await.put_block(block.clone());
         self.blocks_sender.send_replace(block.header.number);
         Ok(())
     }
@@ -140,16 +134,16 @@ impl WriteBlockStore for InMemoryStorage {
 
 #[async_trait]
 impl ReplicaStateStore for InMemoryStorage {
-    async fn replica_state(&self, ctx: &ctx::Ctx) -> StorageResult<Option<ReplicaState>> {
-        Ok(sync::lock(ctx, &self.replica_state).await?.clone())
+    async fn replica_state(&self, _ctx: &ctx::Ctx) -> StorageResult<Option<ReplicaState>> {
+        Ok(self.replica_state.lock().await.clone())
     }
 
     async fn put_replica_state(
         &self,
-        ctx: &ctx::Ctx,
+        _ctx: &ctx::Ctx,
         replica_state: &ReplicaState,
     ) -> StorageResult<()> {
-        *sync::lock(ctx, &self.replica_state).await? = Some(replica_state.clone());
+        *self.replica_state.lock().await = Some(replica_state.clone());
         Ok(())
     }
 }

--- a/node/libs/storage/src/tests/mod.rs
+++ b/node/libs/storage/src/tests/mod.rs
@@ -149,10 +149,3 @@ fn test_schema_encode_decode() {
         zksync_protobuf::decode(&zksync_protobuf::encode(&replica)).unwrap()
     );
 }
-
-#[test]
-fn cancellation_is_detected_in_storage_errors() {
-    let err = StorageError::from(ctx::Canceled);
-    let err = anyhow::Error::from(err);
-    assert!(err.root_cause().is::<ctx::Canceled>());
-}

--- a/node/libs/storage/src/types.rs
+++ b/node/libs/storage/src/types.rs
@@ -2,7 +2,6 @@
 use crate::proto;
 use anyhow::Context as _;
 use std::{iter, ops};
-use zksync_concurrency::ctx;
 use zksync_consensus_roles::validator::{self, BlockNumber};
 use zksync_protobuf::{read_required, required, ProtoFmt};
 
@@ -132,16 +131,7 @@ where
     }
 }
 
-/// Storage errors.
-#[derive(Debug, thiserror::Error)]
-pub enum StorageError {
-    /// Operation was canceled by structured concurrency framework.
-    #[error("operation was canceled by structured concurrency framework")]
-    Canceled(#[from] ctx::Canceled),
-    /// Database operation failed.
-    #[error("database operation failed")]
-    Database(#[source] anyhow::Error),
-}
+pub type StorageError = zksync_concurrency::ctx::Error;
 
 /// [`Result`] for fallible storage operations.
 pub type StorageResult<T> = Result<T, StorageError>;


### PR DESCRIPTION
Added support for adding context to errors types containing anyhow::Error.
It is supposed to reduce the usability gap between anyhow::Error and partially typed errors.