### PR TITLE
Validate signer to be in validator set (BFT-384)

### DIFF
--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -64,6 +64,7 @@ impl StateMachine {
         let message = signed_message.msg;
         let author = &signed_message.key;
 
+        // Check that the message signer is in the validator set.
         consensus
             .validator_set
             .index(author)

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -17,7 +17,7 @@ pub(crate) enum Error {
         local_version: ProtocolVersion,
     },
     /// Message signer isn't part of the validator set.
-    #[error("Message signer isn't part of the validator set")]
+    #[error("Message signer isn't part of the validator set (signer: {signer:?})")]
     NonValidatorSigner {
         /// Signer of the message.
         signer: validator::PublicKey,

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -76,6 +76,7 @@ impl StateMachine {
         let message = signed_message.msg.clone();
         let author = &signed_message.key;
 
+        // Check that the message signer is in the validator set.
         consensus
             .validator_set
             .index(author)

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -19,7 +19,7 @@ pub(crate) enum Error {
         local_version: ProtocolVersion,
     },
     /// Message signer isn't part of the validator set.
-    #[error("Message signer isn't part of the validator set")]
+    #[error("Message signer isn't part of the validator set (signer: {signer:?})")]
     NonValidatorSigner {
         /// Signer of the message.
         signer: validator::PublicKey,

--- a/node/actors/bft/src/leader/tests.rs
+++ b/node/actors/bft/src/leader/tests.rs
@@ -290,27 +290,6 @@ async fn replica_prepare_high_qc_of_future_view() {
 }
 
 #[tokio::test]
-async fn replica_prepare_non_validator_signer_one_from_many() {
-    let mut util = UTHarness::new_many().await;
-
-    util.set_view(util.owner_as_view_leader());
-
-    let replica_prepare = util.new_current_replica_prepare(|_| {}).cast().unwrap().msg;
-    let mut keys = util.keys()[0..util.consensus_threshold() - 1].to_vec();
-    let non_validator_key: validator::SecretKey = util.rng().gen();
-    keys.push(non_validator_key.clone());
-
-    let res =
-        util.dispatch_replica_prepare_many(vec![replica_prepare; util.consensus_threshold()], keys);
-    assert_matches!(
-        res,
-        Err(ReplicaPrepareError::NonValidatorSigner { signer }) => {
-            assert_eq!(signer, non_validator_key.public());
-        }
-    );
-}
-
-#[tokio::test]
 async fn replica_commit_sanity() {
     let mut util = UTHarness::new_many().await;
 

--- a/node/actors/bft/src/testonly/ut_harness.rs
+++ b/node/actors/bft/src/testonly/ut_harness.rs
@@ -318,6 +318,7 @@ impl UTHarness {
             .unwrap()
     }
 
+    #[allow(clippy::result_large_err)]
     pub(crate) fn dispatch_replica_commit_one(
         &mut self,
         msg: Signed<ConsensusMsg>,
@@ -329,6 +330,7 @@ impl UTHarness {
         )
     }
 
+    #[allow(clippy::result_large_err)]
     pub(crate) fn dispatch_replica_commit_many(
         &mut self,
         messages: Vec<ReplicaCommit>,


### PR DESCRIPTION
Add validation for messages sent by replica to have their signer be in the validator set. 

* A new error type variant has been added to the 2 message types.
* Validation has been introduced at the beginning of the processing of each message.
* 2 tests have been added:
    * `replica_prepare_non_validator_signer`
    * `replica_commit_non_validator_signer`
