### PR TITLE
Handle quorum certificate failure gracefully (BFT-386)

### DIFF
--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -62,6 +62,9 @@ pub(crate) enum Error {
     /// Invalid `HighQC` message.
     #[error("invalid high QC: {0:#}")]
     InvalidHighQC(#[source] anyhow::Error),
+    /// Unexpected error when creating justification from received messages.
+    #[error("create justification unexpected error: {0:#}")]
+    CreateJustificationUnexpectedError(#[source] anyhow::Error),
 }
 
 impl StateMachine {
@@ -225,7 +228,7 @@ impl StateMachine {
 
         // Create the justification for our message.
         let justification = validator::PrepareQC::from(&replica_messages, &consensus.validator_set)
-            .expect("Couldn't create justification from valid replica messages!");
+            .map_err(Error::CreateJustificationUnexpectedError)?;
 
         // Broadcast the leader prepare message to all replicas (ourselves included).
         let output_message = ConsensusInputMessage {


### PR DESCRIPTION
Leader should not panic when it fails to create commit/prepare quorum certificate. Instead, the triggering message processing should return the unexpected error, after cleaning caches, and let the current iteration time out. 

No tests were added since reaching this code path is unexpected and should be unproducible.

---

Another option would be to explicitly advertise the renunciation of the leader’s role within the current view by introducing a new variant of `ConsensusMsg`.

