### PR TITLE
Construct quorum certificate incrementally

### DIFF
--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -67,9 +67,6 @@ pub(crate) enum Error {
     /// Invalid `HighQC` message.
     #[error("invalid high QC: {0:#}")]
     InvalidHighQC(#[source] anyhow::Error),
-    // /// Unexpected error when attempting to incrementally build the prepare QC.
-    // #[error("prepare QC build unexpected error: {0:#}")]
-    // PrepareQCBuildUnexpectedError(#[source] anyhow::Error),
     /// Internal error. Unlike other error types, this one isn't supposed to be easily recoverable.
     #[error(transparent)]
     Internal(#[from] ctx::Error),

--- a/node/libs/crypto/src/bn254/mod.rs
+++ b/node/libs/crypto/src/bn254/mod.rs
@@ -170,15 +170,16 @@ impl Ord for Signature {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AggregateSignature(G1);
 
-impl AggregateSignature {
-    /// Generates an aggregate signature from a list of signatures.
-    pub fn aggregate<'a>(sigs: impl IntoIterator<Item = &'a Signature>) -> Self {
-        let mut agg = G1Affine::zero().into_projective();
-        for sig in sigs {
-            agg.add_assign(&sig.0)
-        }
+impl Default for AggregateSignature {
+    fn default() -> Self {
+        Self(G1Affine::zero().into_projective())
+    }
+}
 
-        AggregateSignature(agg)
+impl AggregateSignature {
+    // Add a signature to the aggregation.
+    pub fn add(&mut self, sig: &Signature) {
+        self.0.add_assign(&sig.0)
     }
 
     /// This function is intentionally non-generic and disallow inlining to ensure that compilation optimizations can be effectively applied.

--- a/node/libs/crypto/src/bn254/testonly.rs
+++ b/node/libs/crypto/src/bn254/testonly.rs
@@ -48,3 +48,14 @@ impl Distribution<AggregateSignature> for Standard {
         AggregateSignature(p)
     }
 }
+
+impl AggregateSignature {
+    /// Generate a new aggregate signature from a list of signatures.
+    pub fn aggregate<'a>(sigs: impl IntoIterator<Item = &'a Signature>) -> Self {
+        let mut agg = Self::default();
+        for sig in sigs {
+            agg.add(&sig);
+        }
+        agg
+    }
+}

--- a/node/libs/roles/src/validator/keys/aggregate_signature.rs
+++ b/node/libs/roles/src/validator/keys/aggregate_signature.rs
@@ -5,15 +5,13 @@ use zksync_consensus_crypto::{bn254, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::Variant;
 
 /// An aggregate signature from a validator.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct AggregateSignature(pub(crate) bn254::AggregateSignature);
 
 impl AggregateSignature {
-    /// Generate  a new aggregate signature from a list of signatures.
-    pub fn aggregate<'a>(sigs: impl IntoIterator<Item = &'a Signature>) -> Self {
-        Self(bn254::AggregateSignature::aggregate(
-            sigs.into_iter().map(|sig| &sig.0).collect::<Vec<_>>(),
-        ))
+    // Add a signature to the aggregation.
+    pub fn add(&mut self, sig: &Signature) {
+        self.0.add(&sig.0)
     }
 
     /// Verify a list of messages against a list of public keys.


### PR DESCRIPTION
Constructing quorum certificates from a batch of signed messages creates redundant error checks which are hard to reason about. 

Since this operation's failure is unacceptable and can only occur as a result of a bug, it is preferred to construct incrementally upon receiving each message.

However, this refactoring ended up with no error checks during the incremental construction, delegating responsibility to the message processing.

Consequently, this change can be viewed merely as code cleanup which removes redundant error checks, and the incremental steps as a safer way to do that.

### Notes
* `PrepareQCBuilder` &`CommitQCBuilder` structs were added on top of the underlying structs
* Batch-mode functions throughout the stack are no longer used in non-test code, and were moved to `testonly`. They can be removed altogether if tests will construct incrementally as well.
    * `PrepareQC::from`
    * `CommitQC::from` (also seemed to had a duplicated error check which was removed)
    * `validator::AggregateSignature::aggregate`
    * `bn254::AggregateSignature::aggregate`

### TODOs (pending concept ACK)
* Refactor tests to construct incrementally (?)
* `PrepareQCBuilder::add`'s `BitVec` handling can be simplified
* `CommitQCBuilder::take` does not consume the builder in the same way as `PrepareQCBuilder::take` because `CommitQC` does not have a clear default value. This can be improved


