### PR TITLE
made bft actor send LeaderPrepare messages asynchronously 

### DIFF
--- a/node/actors/bft/src/inner.rs
+++ b/node/actors/bft/src/inner.rs
@@ -1,11 +1,8 @@
 //! The inner data of the consensus state machine. This is shared between the different roles.
 
-use crate::{
-    io::{OutputMessage},
-    misc,
-};
-use zksync_concurrency::{ctx::channel};
+use crate::{io::OutputMessage, misc};
 use tracing::instrument;
+use zksync_concurrency::ctx::channel;
 use zksync_consensus_roles::validator;
 
 /// The ConsensusInner struct, it contains data to be shared with the state machines. This is never supposed

--- a/node/actors/bft/src/inner.rs
+++ b/node/actors/bft/src/inner.rs
@@ -4,6 +4,7 @@ use crate::{
     io::{InputMessage, OutputMessage},
     misc,
 };
+use zksync_concurrency::{ctx::channel};
 use tracing::instrument;
 use zksync_consensus_roles::validator;
 use zksync_consensus_utils::pipe::ActorPipe;
@@ -13,7 +14,7 @@ use zksync_consensus_utils::pipe::ActorPipe;
 #[derive(Debug)]
 pub(crate) struct ConsensusInner {
     /// The communication pipe. This is used to receive inputs and send outputs.
-    pub(crate) pipe: ActorPipe<InputMessage, OutputMessage>,
+    pub(crate) pipe: channel::UnboundedSender<OutputMessage>,
     /// The validator's secret key.
     pub(crate) secret_key: validator::SecretKey,
     /// A vector of public keys for all the validators in the network.

--- a/node/actors/bft/src/inner.rs
+++ b/node/actors/bft/src/inner.rs
@@ -1,13 +1,12 @@
 //! The inner data of the consensus state machine. This is shared between the different roles.
 
 use crate::{
-    io::{InputMessage, OutputMessage},
+    io::{OutputMessage},
     misc,
 };
 use zksync_concurrency::{ctx::channel};
 use tracing::instrument;
 use zksync_consensus_roles::validator;
-use zksync_consensus_utils::pipe::ActorPipe;
 
 /// The ConsensusInner struct, it contains data to be shared with the state machines. This is never supposed
 /// to be modified, except by the Consensus struct.

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -1,5 +1,5 @@
 use super::StateMachine;
-use crate::{inner::ConsensusInner, metrics, Consensus};
+use crate::{metrics};
 use tracing::instrument;
 use zksync_concurrency::{ctx, metrics::LatencyHistogramExt as _};
 use zksync_consensus_network::io::{ConsensusInputMessage, Target};
@@ -72,10 +72,10 @@ impl StateMachine {
         let author = &signed_message.key;
 
         // Check protocol version compatibility.
-        if !Consensus::PROTOCOL_VERSION.compatible(&message.protocol_version) {
+        if !crate::PROTOCOL_VERSION.compatible(&message.protocol_version) {
             return Err(Error::IncompatibleProtocolVersion {
                 message_version: message.protocol_version,
-                local_version: Consensus::PROTOCOL_VERSION,
+                local_version: crate::PROTOCOL_VERSION,
             });
         }
 
@@ -177,7 +177,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderCommit(
                     validator::LeaderCommit {
-                        protocol_version: Consensus::PROTOCOL_VERSION,
+                        protocol_version: crate::PROTOCOL_VERSION,
                         justification,
                     },
                 )),

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -1,5 +1,5 @@
 use super::StateMachine;
-use crate::{inner::ConsensusInner, metrics, Consensus};
+use crate::{metrics};
 use std::collections::HashMap;
 use tracing::instrument;
 use zksync_concurrency::{ctx, error::Wrap};
@@ -98,15 +98,15 @@ impl StateMachine {
         let author = &signed_message.key;
 
         // Check protocol version compatibility.
-        if !Consensus::PROTOCOL_VERSION.compatible(&message.protocol_version) {
+        if !crate::PROTOCOL_VERSION.compatible(&message.protocol_version) {
             return Err(Error::IncompatibleProtocolVersion {
                 message_version: message.protocol_version,
-                local_version: Consensus::PROTOCOL_VERSION,
+                local_version: crate::PROTOCOL_VERSION,
             });
         }
 
         // Check that the message signer is in the validator set.
-        self.inner.
+        self.inner
             .validator_set
             .index(author)
             .ok_or(Error::NonValidatorSigner {
@@ -257,7 +257,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderPrepare(
                     validator::LeaderPrepare {
-                        protocol_version: Consensus::PROTOCOL_VERSION,
+                        protocol_version: crate::PROTOCOL_VERSION,
                         view: self.view,
                         proposal,
                         proposal_payload: payload,

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -89,7 +89,6 @@ impl StateMachine {
     pub(crate) async fn process_replica_prepare(
         &mut self,
         ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
         signed_message: validator::Signed<validator::ReplicaPrepare>,
     ) -> Result<(), Error> {
         // ----------- Checking origin of the message --------------
@@ -107,7 +106,7 @@ impl StateMachine {
         }
 
         // Check that the message signer is in the validator set.
-        consensus
+        self.inner.
             .validator_set
             .index(author)
             .ok_or(Error::NonValidatorSigner {
@@ -123,7 +122,7 @@ impl StateMachine {
         }
 
         // If the message is for a view when we are not a leader, we discard it.
-        if consensus.view_leader(message.view) != consensus.secret_key.public() {
+        if self.inner.view_leader(message.view) != self.inner.secret_key.public() {
             return Err(Error::NotLeaderInView);
         }
 
@@ -148,7 +147,7 @@ impl StateMachine {
         // Verify the high QC.
         message
             .high_qc
-            .verify(&consensus.validator_set, consensus.threshold())
+            .verify(&self.inner.validator_set, self.inner.threshold())
             .map_err(Error::InvalidHighQC)?;
 
         // If the high QC is for a future view, we discard the message.
@@ -172,10 +171,10 @@ impl StateMachine {
         // Now we check if we have enough messages to continue.
         let num_messages = self.prepare_message_cache.get(&message.view).unwrap().len();
 
-        if num_messages < consensus.threshold() {
+        if num_messages < self.inner.threshold() {
             return Err(Error::NumReceivedBelowThreshold {
                 num_messages,
-                threshold: consensus.threshold(),
+                threshold: self.inner.threshold(),
             });
         }
 
@@ -191,7 +190,7 @@ impl StateMachine {
             .into_values()
             .collect();
 
-        debug_assert!(num_messages == consensus.threshold());
+        debug_assert!(num_messages == self.inner.threshold());
 
         // Get the highest block voted for and check if there's a quorum of votes for it. To have a quorum
         // in this situation, we require 2*f+1 votes, where f is the maximum number of faulty replicas.
@@ -204,7 +203,7 @@ impl StateMachine {
         let highest_vote: Option<validator::BlockHeader> = count
             .iter()
             // We only take one value from the iterator because there can only be at most one block with a quorum of 2f+1 votes.
-            .find(|(_, v)| **v > 2 * consensus.faulty_replicas())
+            .find(|(_, v)| **v > 2 * self.inner.faulty_replicas())
             .map(|(h, _)| h)
             .cloned();
 
@@ -248,12 +247,13 @@ impl StateMachine {
         // ----------- Prepare our message and send it --------------
 
         // Create the justification for our message.
-        let justification = validator::PrepareQC::from(&replica_messages, &consensus.validator_set)
+        let justification = validator::PrepareQC::from(&replica_messages, &self.inner.validator_set)
             .expect("Couldn't create justification from valid replica messages!");
 
         // Broadcast the leader prepare message to all replicas (ourselves included).
         let output_message = ConsensusInputMessage {
-            message: consensus
+            message: self
+                .inner
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::LeaderPrepare(
                     validator::LeaderPrepare {
@@ -266,7 +266,7 @@ impl StateMachine {
                 )),
             recipient: Target::Broadcast,
         };
-        consensus.pipe.send(output_message.into());
+        self.inner.pipe.send(output_message.into());
 
         Ok(())
     }

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -93,7 +93,7 @@ impl StateMachine {
         Ok(())
     }
 
-    pub async fn run_proposer(
+    pub(crate) async fn run_proposer(
         ctx: &ctx::Ctx,
         inner: &ConsensusInner,
         payload_source: &dyn PayloadSource,
@@ -105,7 +105,7 @@ impl StateMachine {
             let Some(prepare_qc) = prepare_qc.borrow_and_update().clone() else { continue };
             if next_view < prepare_qc.view() { continue };
             next_view = prepare_qc.view();
-            let msg = Self::propose(ctx,inner,payload_source, prepare_qc).await?; 
+            Self::propose(ctx,inner,payload_source, prepare_qc).await?; 
         }
     }
 
@@ -173,9 +173,9 @@ impl StateMachine {
                 },
             ));
         inner.pipe.send(ConsensusInputMessage {
-            message: msg.embed().into(),
+            message: msg,
             recipient: Target::Broadcast,
-        });
+        }.into());
         Ok(())
     }
 }

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -5,16 +5,15 @@ use std::{
     unreachable,
 };
 use tracing::instrument;
-use zksync_concurrency::{ctx, error::Wrap as _, metrics::LatencyHistogramExt as _, time};
+use zksync_concurrency::{ctx, sync, error::Wrap as _, metrics::LatencyHistogramExt as _, time};
 use zksync_consensus_roles::validator;
+use zksync_consensus_network::io::{ConsensusInputMessage, Target};
 
 /// The StateMachine struct contains the state of the leader. This is a simple state machine. We just store
 /// replica messages and produce leader messages (including proposing blocks) when we reach the threshold for
 /// those messages. When participating in consensus we are not the leader most of the time.
 pub(crate) struct StateMachine {
     pub(crate) inner: Arc<ConsensusInner>,
-    /// Payload provider for the new blocks.
-    pub(crate) payload_source: Arc<dyn PayloadSource>,
     /// The current view number. This might not match the replica's view number, we only have this here
     /// to make the leader advance monotonically in time and stop it from accepting messages from the past.
     pub(crate) view: validator::ViewNumber,
@@ -23,8 +22,6 @@ pub(crate) struct StateMachine {
     pub(crate) phase: validator::Phase,
     /// Time when the current phase has started.
     pub(crate) phase_start: time::Instant,
-    /// A cache of our latest block proposal. We use it to determine if we accept a replica commit message.
-    pub(crate) block_proposal_cache: Option<validator::BlockHeader>,
     /// A cache of replica prepare messages indexed by view number and validator.
     pub(crate) prepare_message_cache: BTreeMap<
         validator::ViewNumber,
@@ -35,21 +32,22 @@ pub(crate) struct StateMachine {
         validator::ViewNumber,
         HashMap<validator::PublicKey, validator::Signed<validator::ReplicaCommit>>,
     >,
+    /// Newest quorum certificate composed from the `ReplicaPrepare` messages.
+    pub(crate) prepare_qc: sync::watch::Sender<Option<validator::PrepareQC>>,
 }
 
 impl StateMachine {
     /// Creates a new StateMachine struct.
-    #[instrument(level = "trace", skip(payload_source))]
-    pub fn new(ctx: &ctx::Ctx, inner: Arc<ConsensusInner>, payload_source: Arc<dyn PayloadSource>) -> Self {
+    #[instrument(level = "trace")]
+    pub fn new(ctx: &ctx::Ctx, inner: Arc<ConsensusInner>) -> Self {
         StateMachine {
             inner,
-            payload_source,
             view: validator::ViewNumber(0),
             phase: validator::Phase::Prepare,
             phase_start: ctx.now(),
-            block_proposal_cache: None,
             prepare_message_cache: BTreeMap::new(),
             commit_message_cache: BTreeMap::new(),
+            prepare_qc: sync::watch::channel(None).0,
         }
     }
 
@@ -92,6 +90,92 @@ impl StateMachine {
             _ => unreachable!(),
         };
         metrics::METRICS.leader_processing_latency[&label].observe_latency(ctx.now() - now);
+        Ok(())
+    }
+
+    pub async fn run_proposer(
+        ctx: &ctx::Ctx,
+        inner: &ConsensusInner,
+        payload_source: &dyn PayloadSource,
+        mut prepare_qc: sync::watch::Receiver<Option<validator::PrepareQC>>,
+    ) -> ctx::Result<()> {
+        let mut next_view = validator::ViewNumber(0);
+        loop {
+            sync::changed(ctx, &mut prepare_qc).await?;
+            let Some(prepare_qc) = prepare_qc.borrow_and_update().clone() else { continue };
+            if next_view < prepare_qc.view() { continue };
+            next_view = prepare_qc.view();
+            let msg = Self::propose(ctx,inner,payload_source, prepare_qc).await?; 
+        }
+    }
+
+    pub(crate) async fn propose(
+        ctx: &ctx::Ctx,
+        inner: &ConsensusInner,
+        payload_source: &dyn PayloadSource,
+        justification: validator::PrepareQC,
+    ) -> ctx::Result<()> {
+        // Get the highest block voted for and check if there's a quorum of votes for it. To have a quorum
+        // in this situation, we require 2*f+1 votes, where f is the maximum number of faulty replicas.
+        let mut count: HashMap<_, usize> = HashMap::new();
+
+        for (vote,signers) in justification.map.iter() {
+            *count.entry(vote.high_vote.proposal).or_default() += signers.len();
+        }
+
+        let highest_vote: Option<validator::BlockHeader> = count
+            .iter()
+            // We only take one value from the iterator because there can only be at most one block with a quorum of 2f+1 votes.
+            .find(|(_, v)| **v > 2 * inner.faulty_replicas())
+            .map(|(h, _)| h)
+            .cloned();
+
+        // Get the highest CommitQC.
+        let highest_qc: &validator::CommitQC = justification.map.keys()
+            .map(|s| &s.high_qc)
+            .max_by_key(|qc| qc.message.view)
+            .unwrap();
+
+        // Create the block proposal to send to the replicas,
+        // and the commit vote to store in our block proposal cache.
+        let (proposal, payload) = match highest_vote {
+            // The previous block was not finalized, so we need to propose it again.
+            // For this we only need the header, since we are guaranteed that at least
+            // f+1 honest replicas have the block and can broadcast it when finalized
+            // (2f+1 have stated that they voted for the block, at most f are malicious).
+            Some(proposal) if proposal != highest_qc.message.proposal => (proposal, None),
+            // The previous block was finalized, so we can propose a new block.
+            _ => {
+                let payload = payload_source
+                    .propose(ctx, highest_qc.message.proposal.number.next())
+                    .await?;
+                metrics::METRICS
+                    .leader_proposal_payload_size
+                    .observe(payload.0.len());
+                let proposal =
+                    validator::BlockHeader::new(&highest_qc.message.proposal, payload.hash());
+                (proposal, Some(payload))
+            }
+        };
+
+        // ----------- Prepare our message and send it --------------
+
+        // Broadcast the leader prepare message to all replicas (ourselves included).
+        let msg = inner
+            .secret_key
+            .sign_msg(validator::ConsensusMsg::LeaderPrepare(
+                validator::LeaderPrepare {
+                    protocol_version: crate::PROTOCOL_VERSION,
+                    view: justification.view(),
+                    proposal,
+                    proposal_payload: payload,
+                    justification,
+                },
+            ));
+        inner.pipe.send(ConsensusInputMessage {
+            message: msg.embed().into(),
+            recipient: Target::Broadcast,
+        });
         Ok(())
     }
 }

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -60,14 +60,13 @@ impl StateMachine {
     pub(crate) async fn process_input(
         &mut self,
         ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
         input: validator::Signed<validator::ConsensusMsg>,
     ) -> ctx::Result<()> {
         let now = ctx.now();
         let label = match &input.msg {
             validator::ConsensusMsg::ReplicaPrepare(_) => {
                 let res = match self
-                    .process_replica_prepare(ctx, consensus, input.cast().unwrap())
+                    .process_replica_prepare(ctx, input.cast().unwrap())
                     .await
                     .wrap("process_replica_prepare()")
                 {
@@ -84,7 +83,7 @@ impl StateMachine {
             }
             validator::ConsensusMsg::ReplicaCommit(_) => {
                 let res = self
-                    .process_replica_commit(ctx, consensus, input.cast().unwrap())
+                    .process_replica_commit(ctx, input.cast().unwrap())
                     .map_err(|err| {
                         tracing::warn!("process_replica_commit: {err:#}");
                     });

--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -12,6 +12,7 @@ use zksync_consensus_roles::validator;
 /// replica messages and produce leader messages (including proposing blocks) when we reach the threshold for
 /// those messages. When participating in consensus we are not the leader most of the time.
 pub(crate) struct StateMachine {
+    pub(crate) inner: Arc<ConsensusInner>,
     /// Payload provider for the new blocks.
     pub(crate) payload_source: Arc<dyn PayloadSource>,
     /// The current view number. This might not match the replica's view number, we only have this here
@@ -39,8 +40,9 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct.
     #[instrument(level = "trace", skip(payload_source))]
-    pub fn new(ctx: &ctx::Ctx, payload_source: Arc<dyn PayloadSource>) -> Self {
+    pub fn new(ctx: &ctx::Ctx, inner: Arc<ConsensusInner>, payload_source: Arc<dyn PayloadSource>) -> Self {
         StateMachine {
+            inner,
             payload_source,
             view: validator::ViewNumber(0),
             phase: validator::Phase::Prepare,

--- a/node/actors/bft/src/leader/tests.rs
+++ b/node/actors/bft/src/leader/tests.rs
@@ -410,16 +410,9 @@ async fn replica_commit_num_received_below_threshold() {
         .process_leader_prepare(ctx, leader_prepare)
         .await
         .unwrap();
-    let res = util
+    util
         .process_replica_commit(ctx, replica_commit.clone())
-        .await;
-    assert_matches!(
-        res,
-        Err(ReplicaCommitError::NumReceivedBelowThreshold {
-            num_messages: 1,
-            threshold: 2
-        })
-    );
+        .await.unwrap();
 }
 
 #[tokio::test]
@@ -439,6 +432,5 @@ async fn replica_commit_unexpected_proposal() {
     let ctx = &ctx::test_root(&ctx::RealClock);
     let mut util = UTHarness::new(ctx, 1).await;
     let replica_commit = util.new_current_replica_commit(|_| {});
-    let res = util.process_replica_commit(ctx, replica_commit).await;
-    assert_matches!(res, Err(ReplicaCommitError::UnexpectedProposal));
+    util.process_replica_commit(ctx, replica_commit).await.unwrap();
 }

--- a/node/actors/bft/src/lib.rs
+++ b/node/actors/bft/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn run(
         let mut replica = replica::StateMachine::start(ctx, inner.clone(), storage).await?;
         let mut leader = leader::StateMachine::new(ctx, inner.clone());
 
-        s.spawn_bg(leader::StateMachine::run_proposer(ctx, inner, payload_source, leader.prepare_qc.subscribe()));
+        s.spawn_bg(leader::StateMachine::run_proposer(ctx, &*inner, payload_source, leader.prepare_qc.subscribe()));
 
         tracing::info!(
             "Starting consensus actor {:?}",

--- a/node/actors/bft/src/replica/block.rs
+++ b/node/actors/bft/src/replica/block.rs
@@ -1,5 +1,4 @@
 use super::StateMachine;
-use crate::inner::ConsensusInner;
 use anyhow::Context as _;
 use tracing::{info, instrument};
 use zksync_concurrency::ctx;

--- a/node/actors/bft/src/replica/block.rs
+++ b/node/actors/bft/src/replica/block.rs
@@ -13,7 +13,6 @@ impl StateMachine {
     pub(crate) async fn save_block(
         &mut self,
         ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
         commit_qc: &validator::CommitQC,
     ) -> ctx::Result<()> {
         // TODO(gprusak): for availability of finalized blocks,

--- a/node/actors/bft/src/replica/leader_commit.rs
+++ b/node/actors/bft/src/replica/leader_commit.rs
@@ -123,9 +123,7 @@ impl StateMachine {
 
         // Start a new view. But first we skip to the view of this message.
         self.view = view;
-        self.start_new_view(ctx)
-            .await
-            .wrap("start_new_view()")?;
+        self.start_new_view(ctx).await.wrap("start_new_view()")?;
 
         Ok(())
     }

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -1,5 +1,5 @@
 use super::StateMachine;
-use crate::{inner::ConsensusInner};
+use crate::inner::ConsensusInner;
 use std::collections::HashMap;
 use tracing::instrument;
 use zksync_concurrency::{ctx, error::Wrap};

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -1,5 +1,5 @@
 use super::StateMachine;
-use crate::{inner::ConsensusInner, Consensus};
+use crate::{inner::ConsensusInner};
 use std::collections::HashMap;
 use tracing::instrument;
 use zksync_concurrency::{ctx, error::Wrap};
@@ -143,10 +143,10 @@ impl StateMachine {
         let view = message.view;
 
         // Check protocol version compatibility.
-        if !Consensus::PROTOCOL_VERSION.compatible(&message.protocol_version) {
+        if !crate::PROTOCOL_VERSION.compatible(&message.protocol_version) {
             return Err(Error::IncompatibleProtocolVersion {
                 message_version: message.protocol_version,
-                local_version: Consensus::PROTOCOL_VERSION,
+                local_version: crate::PROTOCOL_VERSION,
             });
         }
 
@@ -296,7 +296,7 @@ impl StateMachine {
 
         // Create our commit vote.
         let commit_vote = validator::ReplicaCommit {
-            protocol_version: Consensus::PROTOCOL_VERSION,
+            protocol_version: crate::PROTOCOL_VERSION,
             view,
             proposal: message.proposal,
         };

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -11,7 +11,6 @@ impl StateMachine {
     pub(crate) async fn start_new_view(
         &mut self,
         ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
     ) -> ctx::Result<()> {
         tracing::info!("Starting view {}", self.view.next().0);
 
@@ -30,7 +29,7 @@ impl StateMachine {
 
         // Send the replica message to the next leader.
         let output_message = ConsensusInputMessage {
-            message: consensus
+            message: self.inner 
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                     validator::ReplicaPrepare {
@@ -40,9 +39,9 @@ impl StateMachine {
                         high_qc: self.high_qc.clone(),
                     },
                 )),
-            recipient: Target::Validator(consensus.view_leader(next_view)),
+            recipient: Target::Validator(self.inner.view_leader(next_view)),
         };
-        consensus.pipe.send(output_message.into());
+        self.inner.pipe.send(output_message.into());
 
         // Reset the timer.
         self.reset_timer(ctx);

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -1,5 +1,4 @@
 use super::StateMachine;
-use crate::{Consensus, ConsensusInner};
 use tracing::instrument;
 use zksync_concurrency::{ctx, error::Wrap as _};
 use zksync_consensus_network::io::{ConsensusInputMessage, Target};
@@ -33,7 +32,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                     validator::ReplicaPrepare {
-                        protocol_version: Consensus::PROTOCOL_VERSION,
+                        protocol_version: crate::PROTOCOL_VERSION,
                         view: next_view,
                         high_vote: self.high_vote,
                         high_qc: self.high_qc.clone(),

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -7,10 +7,7 @@ use zksync_consensus_roles::validator;
 impl StateMachine {
     /// This blocking method is used whenever we start a new view.
     #[instrument(level = "trace", err)]
-    pub(crate) async fn start_new_view(
-        &mut self,
-        ctx: &ctx::Ctx,
-    ) -> ctx::Result<()> {
+    pub(crate) async fn start_new_view(&mut self, ctx: &ctx::Ctx) -> ctx::Result<()> {
         tracing::info!("Starting view {}", self.view.next().0);
 
         // Update the state machine.
@@ -28,7 +25,8 @@ impl StateMachine {
 
         // Send the replica message to the next leader.
         let output_message = ConsensusInputMessage {
-            message: self.inner 
+            message: self
+                .inner
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaPrepare(
                     validator::ReplicaPrepare {

--- a/node/actors/bft/src/replica/state_machine.rs
+++ b/node/actors/bft/src/replica/state_machine.rs
@@ -5,11 +5,13 @@ use zksync_concurrency::{ctx, error::Wrap as _, metrics::LatencyHistogramExt as 
 use zksync_consensus_roles::validator;
 use zksync_consensus_storage as storage;
 use zksync_consensus_storage::ReplicaStore;
+use std::sync::Arc;
 
 /// The StateMachine struct contains the state of the replica. This is the most complex state machine and is responsible
 /// for validating and voting on blocks. When participating in consensus we are always a replica.
 #[derive(Debug)]
 pub(crate) struct StateMachine {
+    pub(crate) inner: Arc<ConsensusInner>,
     /// The current view number.
     pub(crate) view: validator::ViewNumber,
     /// The current phase.
@@ -31,7 +33,7 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Creates a new StateMachine struct. We try to recover a past state from the storage module,
     /// otherwise we initialize the state machine with whatever head block we have.
-    pub(crate) async fn new(ctx: &ctx::Ctx, storage: ReplicaStore) -> anyhow::Result<Self> {
+    pub(crate) async fn start(ctx: &ctx::Ctx, inner: Arc<ConsensusInner>, storage: ReplicaStore) -> ctx::Result<Self> {
         let backup = storage.replica_state(ctx).await?;
         let mut block_proposal_cache: BTreeMap<_, HashMap<_, _>> = BTreeMap::new();
         for proposal in backup.proposals {
@@ -41,7 +43,8 @@ impl StateMachine {
                 .insert(proposal.payload.hash(), proposal.payload);
         }
 
-        Ok(Self {
+        let this = Self {
+            inner,
             view: backup.view,
             phase: backup.phase,
             high_vote: backup.high_vote,
@@ -49,26 +52,14 @@ impl StateMachine {
             block_proposal_cache,
             timeout_deadline: time::Deadline::Infinite,
             storage,
-        })
-    }
-
-    /// Starts the state machine. The replica state needs to be initialized before
-    /// we are able to process inputs. If we are in the genesis block, then we start a new view,
-    /// this will kick start the consensus algorithm. Otherwise, we just start the timer.
-    #[instrument(level = "trace", ret)]
-    pub(crate) async fn start(
-        &mut self,
-        ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
-    ) -> ctx::Result<()> {
-        if self.view == validator::ViewNumber(0) {
-            self.start_new_view(ctx, consensus)
-                .await
-                .wrap("start_new_view()")
+        };
+        // We need to start the replica before processing inputs.
+        if this.view == validator::ViewNumber(0) {
+            this.start_new_view(ctx).await.wrap("start_new_view()")?;
         } else {
-            self.reset_timer(ctx);
-            Ok(())
+            this.reset_timer(ctx);
         }
+        Ok(this)
     }
 
     /// Process an input message (it will be None if the channel timed out waiting for a message). This is
@@ -78,21 +69,13 @@ impl StateMachine {
     pub(crate) async fn process_input(
         &mut self,
         ctx: &ctx::Ctx,
-        consensus: &ConsensusInner,
-        input: Option<validator::Signed<validator::ConsensusMsg>>,
+        input: validator::Signed<validator::ConsensusMsg>,
     ) -> ctx::Result<()> {
-        let Some(signed_msg) = input else {
-            tracing::warn!("We timed out before receiving a message.");
-            // Start new view.
-            self.start_new_view(ctx, consensus).await?;
-            return Ok(());
-        };
-
         let now = ctx.now();
         let label = match &signed_msg.msg {
             validator::ConsensusMsg::LeaderPrepare(_) => {
                 let res = match self
-                    .process_leader_prepare(ctx, consensus, signed_msg.cast().unwrap())
+                    .process_leader_prepare(ctx, signed_msg.cast().unwrap())
                     .await
                     .wrap("process_leader_prepare()")
                 {
@@ -107,7 +90,7 @@ impl StateMachine {
             }
             validator::ConsensusMsg::LeaderCommit(_) => {
                 let res = match self
-                    .process_leader_commit(ctx, consensus, signed_msg.cast().unwrap())
+                    .process_leader_commit(ctx, signed_msg.cast().unwrap())
                     .await
                     .wrap("process_leader_commit()")
                 {

--- a/node/actors/bft/src/testonly/make.rs
+++ b/node/actors/bft/src/testonly/make.rs
@@ -1,7 +1,5 @@
 //! This module contains utilities that are only meant for testing purposes.
-use crate::{
-    ConsensusInner, PayloadSource,
-};
+use crate::{ConsensusInner, PayloadSource};
 use rand::Rng as _;
 use zksync_concurrency::ctx;
 use zksync_consensus_roles::validator;

--- a/node/actors/bft/src/testonly/make.rs
+++ b/node/actors/bft/src/testonly/make.rs
@@ -1,14 +1,10 @@
 //! This module contains utilities that are only meant for testing purposes.
 use crate::{
-    io::{InputMessage, OutputMessage},
-    Consensus, ConsensusInner, PayloadSource,
+    ConsensusInner, PayloadSource,
 };
 use rand::Rng as _;
-use std::sync::Arc;
 use zksync_concurrency::ctx;
 use zksync_consensus_roles::validator;
-use zksync_consensus_storage::{InMemoryStorage, ReplicaStore};
-use zksync_consensus_utils::pipe::{self, DispatcherPipe};
 
 /// Provides payload consisting of random bytes.
 pub struct RandomPayloadSource;
@@ -24,32 +20,6 @@ impl PayloadSource for RandomPayloadSource {
         ctx.rng().fill(&mut payload.0[..]);
         Ok(payload)
     }
-}
-
-/// This creates a mock Consensus struct for unit tests.
-pub async fn make_consensus(
-    ctx: &ctx::Ctx,
-    key: &validator::SecretKey,
-    validator_set: &validator::ValidatorSet,
-    genesis_block: &validator::FinalBlock,
-) -> (Consensus, DispatcherPipe<InputMessage, OutputMessage>) {
-    // Initialize the storage.
-    let storage = InMemoryStorage::new(genesis_block.clone());
-    // Create the pipe.
-    let (consensus_pipe, dispatcher_pipe) = pipe::new();
-
-    let consensus = Consensus::new(
-        ctx,
-        consensus_pipe,
-        key.clone(),
-        validator_set.clone(),
-        ReplicaStore::from_store(Arc::new(storage)),
-        Arc::new(RandomPayloadSource),
-    );
-    let consensus = consensus
-        .await
-        .expect("Initializing consensus actor failed");
-    (consensus, dispatcher_pipe)
 }
 
 /// Creates a genesis block with the given payload

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -107,7 +107,7 @@ async fn run_nodes(ctx: &ctx::Ctx, network: Network, nodes: &[Node]) -> anyhow::
                             node.net.consensus_config().key.clone(),
                             validator_set,
                             storage,
-                            Arc::new(RandomPayloadSource),
+                            &RandomPayloadSource,
                         ).await.context("consensus.run()") });
                         node.run_executor(ctx, consensus_pipe, network_pipe)
                             .await

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -1,5 +1,5 @@
 use super::{Behavior, Node, RandomPayloadSource};
-use crate::{testonly};
+use crate::testonly;
 use anyhow::Context;
 use std::{collections::HashMap, sync::Arc};
 use tracing::Instrument as _;
@@ -101,14 +101,18 @@ async fn run_nodes(ctx: &ctx::Ctx, network: Network, nodes: &[Node]) -> anyhow::
                     let storage = ReplicaStore::from_store(node.storage.clone());
                     scope::run!(ctx, |ctx, s| async {
                         network_ready.recv(ctx).await?;
-                        s.spawn(async { crate::run(
-                            ctx,
-                            consensus_actor_pipe,
-                            node.net.consensus_config().key.clone(),
-                            validator_set,
-                            storage,
-                            &RandomPayloadSource,
-                        ).await.context("consensus.run()") });
+                        s.spawn(async {
+                            crate::run(
+                                ctx,
+                                consensus_actor_pipe,
+                                node.net.consensus_config().key.clone(),
+                                validator_set,
+                                storage,
+                                &RandomPayloadSource,
+                            )
+                            .await
+                            .context("consensus.run()")
+                        });
                         node.run_executor(ctx, consensus_pipe, network_pipe)
                             .await
                             .context("executor.run()")

--- a/node/actors/bft/src/testonly/ut_harness.rs
+++ b/node/actors/bft/src/testonly/ut_harness.rs
@@ -54,7 +54,6 @@ impl UTHarness {
         let leader = leader::StateMachine::new(
             ctx,
             inner.clone(),
-            Arc::new(RandomPayloadSource),
         );
         let replica = replica::StateMachine::start(
             ctx,
@@ -210,6 +209,7 @@ impl UTHarness {
             .leader
             .process_replica_prepare(ctx, msg)
             .await?;
+        self.
         Ok(self.try_recv())
     }
 
@@ -266,7 +266,8 @@ impl UTHarness {
             let want_threshold = self.replica.inner.threshold();
             match (i + 1).cmp(&want_threshold) {
                 Ordering::Equal => res.unwrap(),
-                Ordering::Less => assert_matches!(
+                Ordering::Less => res.unwrap(),
+                /*assert_matches!(
                     res,
                     Err(ReplicaCommitError::NumReceivedBelowThreshold {
                         num_messages,
@@ -275,7 +276,7 @@ impl UTHarness {
                         assert_eq!(num_messages, i+1);
                         assert_eq!(threshold, want_threshold)
                     }
-                ),
+                ),*/
                 Ordering::Greater => assert_matches!(res, Err(ReplicaCommitError::Old { .. })),
             }
         }

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -86,7 +86,8 @@ async fn timeout_leader_some_prepares() {
     assert!(util
         .process_replica_prepare(ctx, replica_prepare)
         .await
-        .is_err());
+        .unwrap()
+        .is_none());
     util.produce_block_after_timeout(ctx).await;
 }
 
@@ -127,7 +128,8 @@ async fn timeout_leader_some_commits() {
     assert!(util
         .process_replica_commit(ctx, replica_commit)
         .await
-        .is_err());
+        .unwrap()
+        .is_none());
     // Leader is in `Phase::Commit`, but should still accept prepares from newer views.
     assert_eq!(util.leader_phase(), Phase::Commit);
     util.produce_block_after_timeout(ctx).await;

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -99,7 +99,7 @@ async fn timeout_leader_in_commit() {
 
     util.new_leader_prepare(ctx).await;
     // Leader is in `Phase::Commit`, but should still accept prepares from newer views.
-    assert_eq!(util.consensus.leader.phase, Phase::Commit);
+    assert_eq!(util.leader.phase, Phase::Commit);
     util.produce_block_after_timeout(ctx).await;
 }
 
@@ -112,7 +112,7 @@ async fn timeout_replica_in_commit() {
 
     util.new_replica_commit(ctx).await;
     // Leader is in `Phase::Commit`, but should still accept prepares from newer views.
-    assert_eq!(util.consensus.leader.phase, Phase::Commit);
+    assert_eq!(util.leader.phase, Phase::Commit);
     util.produce_block_after_timeout(ctx).await;
 }
 

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -204,7 +204,8 @@ impl<S: WriteBlockStore + 'static> Executor<S> {
             if let Some(validator) = self.validator {
                 s.spawn(async {
                     let validator = validator;
-                    let consensus_storage = ReplicaStore::new(validator.replica_state_store, self.storage.clone());
+                    let consensus_storage =
+                        ReplicaStore::new(validator.replica_state_store, self.storage.clone());
                     zksync_consensus_bft::run(
                         ctx,
                         consensus_actor_pipe,
@@ -212,7 +213,9 @@ impl<S: WriteBlockStore + 'static> Executor<S> {
                         validator_set.clone(),
                         consensus_storage,
                         &*validator.payload_source,
-                    ).await.context("Consensus stopped")
+                    )
+                    .await
+                    .context("Consensus stopped")
                 });
             }
             sync_blocks.run(ctx).await.context("Syncing blocks stopped")

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -6,7 +6,7 @@ use rand::{thread_rng, Rng};
 use std::iter;
 use test_casing::test_casing;
 use zksync_concurrency::{sync, testonly::abort_on_panic, time};
-use zksync_consensus_bft::{testonly::RandomPayloadSource, Consensus};
+use zksync_consensus_bft::{testonly::RandomPayloadSource, PROTOCOL_VERSION};
 use zksync_consensus_roles::validator::{BlockNumber, FinalBlock, Payload};
 use zksync_consensus_storage::{BlockStore, InMemoryStorage};
 
@@ -22,7 +22,7 @@ impl FullValidatorConfig {
                 payload: payload.hash(),
             };
             let commit = self.validator_key.sign_msg(validator::ReplicaCommit {
-                protocol_version: Consensus::PROTOCOL_VERSION,
+                protocol_version: PROTOCOL_VERSION,
                 view: validator::ViewNumber(header.number.0),
                 proposal: header,
             });

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -181,6 +181,11 @@ pub struct PrepareQC {
 }
 
 impl PrepareQC {
+    /// View of the QC.
+    pub fn view(&self) -> ViewNumber {
+        self.map.keys().map(|k|k.view).next().unwrap_or(ViewNumber(0))
+    }
+
     /// Creates a new PrepareQC from a list of *signed* replica Prepare messages and the current validator set.
     pub fn from(
         signed_messages: &[Signed<ReplicaPrepare>],

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -183,7 +183,11 @@ pub struct PrepareQC {
 impl PrepareQC {
     /// View of the QC.
     pub fn view(&self) -> ViewNumber {
-        self.map.keys().map(|k|k.view).next().unwrap_or(ViewNumber(0))
+        self.map
+            .keys()
+            .map(|k| k.view)
+            .next()
+            .unwrap_or(ViewNumber(0))
     }
 
     /// Creates a new PrepareQC from a list of *signed* replica Prepare messages and the current validator set.


### PR DESCRIPTION
## What ❔
Made bft actor send LeaderPrepare messages asynchronously.

## Why ❔
PayloadSource.propose() may be blocking (when no payload can be proposed at a time) but it shouldn't block message processing:
* other validators may be able to propose, so we should keep exchanging messages with them.
* validator should avoid keeping a growing backlog of unprocessed messages
