### PR TITLE
Added `--seed` cli argument to provide IP address, port and key of seed peers on startup

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "rocksdb",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/node/libs/protobuf/src/serde.rs
+++ b/node/libs/protobuf/src/serde.rs
@@ -7,6 +7,22 @@ use crate::ProtoFmt;
 use prost::Message as _;
 use prost_reflect::ReflectMessage;
 
+/// ProtoFmt wrapper which implements serde Serialize/Deserialize.
+#[derive(Debug, Clone)]
+pub struct Serde<T>(pub T);
+
+impl<T: ProtoFmt> serde::Serialize for Serde<T> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize(&self.0, s)
+    }
+}
+
+impl<'de, T: ProtoFmt> serde::Deserialize<'de> for Serde<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(Self(deserialize(d)?))
+    }
+}
+
 /// Implementation of serde::Serialize for arbitrary ReflectMessage.
 pub fn serialize_proto<T: ReflectMessage, S: serde::Serializer>(
     x: &T,

--- a/node/tools/Cargo.toml
+++ b/node/tools/Cargo.toml
@@ -23,6 +23,7 @@ clap.workspace = true
 prost.workspace = true
 rand.workspace = true
 rocksdb.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -118,13 +118,6 @@ impl ProtoFmt for AppConfig {
     }
 }
 
-impl AppConfig {
-    pub fn add_seed_peers(&mut self, seed_peers: Vec<(std::net::SocketAddr, node::PublicKey)>) {
-        for (addr, key) in seed_peers.iter() {
-            self.gossip_static_outbound.insert(key.clone(), *addr);
-        }
-    }
-}
 /// This struct holds the file path to each of the config files.
 #[derive(Debug)]
 pub struct ConfigPaths<'a> {

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 use zksync_concurrency::ctx;
 use zksync_consensus_bft as bft;
@@ -13,12 +12,12 @@ use zksync_consensus_crypto::{read_optional_text, read_required_text, Text, Text
 use zksync_consensus_executor as executor;
 use zksync_consensus_roles::{node, validator};
 use zksync_consensus_storage::{BlockStore, BlockStoreRunner, PersistentBlockStore};
-use zksync_protobuf::{required, ProtoFmt};
+use zksync_protobuf::{required, serde::Serde, ProtoFmt};
 
 /// Decodes a proto message from json for arbitrary ProtoFmt.
-fn decode_json<T: ProtoFmt>(json: &str) -> anyhow::Result<T> {
+pub fn decode_json<T: serde::de::DeserializeOwned>(json: &str) -> anyhow::Result<T> {
     let mut d = serde_json::Deserializer::from_str(json);
-    let p: T = zksync_protobuf::serde::deserialize(&mut d)?;
+    let p = T::deserialize(&mut d)?;
     d.end()?;
     Ok(p)
 }
@@ -34,8 +33,8 @@ impl ProtoFmt for NodeAddr {
     type Proto = proto::NodeAddr;
 
     fn read(r: &Self::Proto) -> anyhow::Result<Self> {
-        let key = read_required_text(&r.key)?;
-        let addr = read_required_text(&r.addr)?;
+        let key = read_required_text(&r.key).context("key")?;
+        let addr = read_required_text(&r.addr).context("addr")?;
         Ok(Self { addr, key })
     }
 
@@ -44,14 +43,6 @@ impl ProtoFmt for NodeAddr {
             key: Some(TextFmt::encode(&self.key)),
             addr: Some(TextFmt::encode(&self.addr)),
         }
-    }
-}
-
-impl FromStr for NodeAddr {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        decode_json(s)
     }
 }
 
@@ -175,9 +166,10 @@ impl<'a> ConfigPaths<'a> {
         Ok(Configs {
             app: (|| {
                 let app = fs::read_to_string(self.app).context("failed reading file")?;
-                decode_json(&app).context("failed decoding JSON")
+                decode_json::<Serde<AppConfig>>(&app).context("failed decoding JSON")
             })()
-            .with_context(|| self.app.display().to_string())?,
+            .with_context(|| self.app.display().to_string())?
+            .0,
 
             validator_key: self
                 .validator_key

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -118,6 +118,13 @@ impl ProtoFmt for AppConfig {
     }
 }
 
+impl AppConfig {
+    pub fn add_seed_peers(&mut self, seed_peers: Vec<(std::net::SocketAddr, node::PublicKey)>) {
+        for (addr, key) in seed_peers.iter() {
+            self.gossip_static_outbound.insert(key.clone(), *addr);
+        }
+    }
+}
 /// This struct holds the file path to each of the config files.
 #[derive(Debug)]
 pub struct ConfigPaths<'a> {

--- a/node/tools/src/lib.rs
+++ b/node/tools/src/lib.rs
@@ -7,4 +7,4 @@ mod store;
 #[cfg(test)]
 mod tests;
 
-pub use config::{AppConfig, ConfigPaths};
+pub use config::{AppConfig, ConfigPaths, NodeAddr};

--- a/node/tools/src/lib.rs
+++ b/node/tools/src/lib.rs
@@ -7,4 +7,4 @@ mod store;
 #[cfg(test)]
 mod tests;
 
-pub use config::{AppConfig, ConfigPaths, NodeAddr};
+pub use config::{decode_json, AppConfig, ConfigPaths, NodeAddr};

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -13,9 +13,10 @@ use zksync_consensus_tools::ConfigPaths;
 use zksync_consensus_utils::no_copy::NoCopy;
 
 #[derive(Debug, Clone)]
-struct NodeAddr(Vec<(node::PublicKey, std::net::SocketAddr)>);
+// Utility struct to parse json value from cli arg
+struct NodeAddresses(Vec<(node::PublicKey, std::net::SocketAddr)>);
 
-impl FromStr for NodeAddr {
+impl FromStr for NodeAddresses {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -32,7 +33,7 @@ impl FromStr for NodeAddr {
                 (key, addr)
             })
             .collect();
-        Ok(NodeAddr(result))
+        Ok(NodeAddresses(result))
     }
 }
 
@@ -54,7 +55,7 @@ struct Args {
     database: PathBuf,
     /// IP address and key of the seed peers.
     #[arg(long = "add_gossip_static_outbound")]
-    gossip_static_outbound: NodeAddr,
+    gossip_static_outbound: NodeAddresses,
 }
 
 impl Args {

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -12,7 +12,7 @@ use zksync_consensus_roles::node;
 use zksync_consensus_tools::ConfigPaths;
 use zksync_consensus_utils::no_copy::NoCopy;
 
-// Utility struct to parse json value from cli arg
+/// Utility struct to parse json value from cli arg
 #[derive(Debug, Clone)]
 struct NodeAddresses(Vec<(node::PublicKey, std::net::SocketAddr)>);
 

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -52,7 +52,7 @@ fn parse_seed_peer(
 ) -> Result<(std::net::SocketAddr, node::PublicKey), Box<dyn Error + Send + Sync>> {
     let pos = s
         .find(',')
-        .ok_or_else(|| format!("expected format: <IP>:<Port>,<key>"))?;
+        .ok_or_else(|| "expected format: <IP>:<Port>,<key>")?;
     Ok((
         s[..pos].parse()?,
         read_required_text(&Some(s[pos + 1..].parse()?))?,

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -12,8 +12,8 @@ use zksync_consensus_roles::node;
 use zksync_consensus_tools::ConfigPaths;
 use zksync_consensus_utils::no_copy::NoCopy;
 
-#[derive(Debug, Clone)]
 // Utility struct to parse json value from cli arg
+#[derive(Debug, Clone)]
 struct NodeAddresses(Vec<(node::PublicKey, std::net::SocketAddr)>);
 
 impl FromStr for NodeAddresses {


### PR DESCRIPTION
## What ❔

Adds a `--seed` command line argument to support seed peer address and key injection when starting the node

Example:
```
executor --seed 10.123.12.21:3043,node:public:ed25519:3059a9ae1de665f2e5dfcb64d5d3a044b2b3617436ddd56c2baf896878b13961 --seed 10.23.22.0:1010,node:public:ed25519:07928c09f2828cbbe1bacc9dc00271c4517c3af1dad034054591e6af10450338
```
will add two IP and key tuples to the `gossipStaticOutbound` in the `config.json` file when starting the node (and it will override the address if the same key is present in the file).

## Why ❔

This will be necessary for the test framework to be able to start nodes within a k8s cluster when initially the IP addresses assigned are unknown. In that sense, we will deploy an initial set of Seed Peers, retrieve their IP addresses and then deploy the rest of the nodes injecting the seed peer addresses and keys via command line arguments.
