### PR TITLE
refactor(protobuf): relocate types from `zksync_protobuf_config` (BFT-407)

### DIFF
--- a/node/libs/protobuf/src/lib.rs
+++ b/node/libs/protobuf/src/lib.rs
@@ -6,6 +6,7 @@ pub mod build;
 pub mod proto;
 mod proto_fmt;
 pub mod repr;
+pub use repr::*;
 pub mod serde;
 mod std_conv;
 pub mod testonly;

--- a/node/libs/protobuf/src/lib.rs
+++ b/node/libs/protobuf/src/lib.rs
@@ -6,7 +6,7 @@ pub mod build;
 pub mod proto;
 mod proto_fmt;
 pub mod repr;
-pub use repr::*;
+pub use repr::{read_required_repr, ProtoRepr};
 pub mod serde;
 mod std_conv;
 pub mod testonly;

--- a/node/libs/protobuf/src/lib.rs
+++ b/node/libs/protobuf/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod build;
 pub mod proto;
 mod proto_fmt;
+pub mod repr;
 pub mod serde;
 mod std_conv;
 pub mod testonly;

--- a/node/libs/protobuf/src/repr.rs
+++ b/node/libs/protobuf/src/repr.rs
@@ -18,3 +18,16 @@ pub trait ProtoRepr: ReflectMessage + Default {
 pub fn read_required_repr<P: ProtoRepr>(field: &Option<P>) -> anyhow::Result<P::Type> {
     field.as_ref().context("missing field")?.read()
 }
+
+/// Encodes a proto message.
+/// Currently it outputs a canonical encoding, but `decode` accepts
+/// non-canonical encoding as well.
+pub fn encode<P: ProtoRepr>(msg: &P::Type) -> Vec<u8> {
+    let msg = P::build(msg);
+    super::canonical_raw(&msg.encode_to_vec(), &msg.descriptor()).unwrap()
+}
+
+/// Decodes a proto message.
+pub fn decode<P: ProtoRepr>(bytes: &[u8]) -> anyhow::Result<P::Type> {
+    P::read(&P::decode(bytes)?)
+}

--- a/node/libs/protobuf/src/repr.rs
+++ b/node/libs/protobuf/src/repr.rs
@@ -1,14 +1,20 @@
+//! `ProtoRepr` utilities.
+
 use crate::build::prost_reflect::ReflectMessage;
 use anyhow::Context as _;
 
 /// Trait reverse to `zksync_protobuf::ProtoFmt` for cases where
 /// you would like to specify a custom proto encoding for an externally defined type.
 pub trait ProtoRepr: ReflectMessage + Default {
+    /// The externally defined type associated with the proto Self.
     type Type;
+    /// Converts proto Self to `Type`.
     fn read(&self) -> anyhow::Result<Self::Type>;
+    /// Converts `Type` to proto Self.
     fn build(this: &Self::Type) -> Self;
 }
 
+/// Parses a required proto field.
 pub fn read_required_repr<P: ProtoRepr>(field: &Option<P>) -> anyhow::Result<P::Type> {
     field.as_ref().context("missing field")?.read()
 }

--- a/node/libs/protobuf/src/repr.rs
+++ b/node/libs/protobuf/src/repr.rs
@@ -1,4 +1,4 @@
-//! `ProtoRepr` utilities.
+//! Trait for defining proto conversion for external types.
 
 use crate::build::prost_reflect::ReflectMessage;
 use anyhow::Context as _;

--- a/node/libs/protobuf/src/repr.rs
+++ b/node/libs/protobuf/src/repr.rs
@@ -1,0 +1,14 @@
+use crate::build::prost_reflect::ReflectMessage;
+use anyhow::Context as _;
+
+/// Trait reverse to `zksync_protobuf::ProtoFmt` for cases where
+/// you would like to specify a custom proto encoding for an externally defined type.
+pub trait ProtoRepr: ReflectMessage + Default {
+    type Type;
+    fn read(&self) -> anyhow::Result<Self::Type>;
+    fn build(this: &Self::Type) -> Self;
+}
+
+pub fn read_required_repr<P: ProtoRepr>(field: &Option<P>) -> anyhow::Result<P::Type> {
+    field.as_ref().context("missing field")?.read()
+}

--- a/node/libs/protobuf/src/testonly/gen_value.rs
+++ b/node/libs/protobuf/src/testonly/gen_value.rs
@@ -1,0 +1,27 @@
+//! Util types for generating random values in tests.
+
+use rand::Rng;
+
+/// Generator of random values.
+pub struct GenValue<'a, R: Rng> {
+    /// Underlying RNG.
+    pub rng: &'a mut R,
+    /// Generate values with only required fields.
+    pub required_only: bool,
+    /// Generate decimal fractions for f64
+    /// to avoid rounding errors of decimal encodings.
+    pub decimal_fractions: bool,
+}
+
+impl<'a, R: Rng> GenValue<'a, R> {
+    /// Generates a random value of type `C`.
+    pub fn gen<C: RandomValue>(&mut self) -> C {
+        C::sample(self)
+    }
+}
+
+/// Types that can be used to generate a random instance.
+pub trait RandomValue {
+    /// Generates a random value.
+    fn sample(g: &mut GenValue<impl Rng>) -> Self;
+}

--- a/node/libs/protobuf/src/testonly/mod.rs
+++ b/node/libs/protobuf/src/testonly/mod.rs
@@ -1,5 +1,8 @@
 //! Testonly utilities.
+
+pub mod gen_value;
 use super::{canonical, canonical_raw, decode, encode, read_fields, ProtoFmt, Wire};
+pub use gen_value::*;
 use prost::Message as _;
 use prost_reflect::ReflectMessage as _;
 use rand::{


### PR DESCRIPTION
## What ❔

Relocating ~`ProtoRepr`~ the following types and utils from `zksync_protobuf_config` ([zksync-era](https://github.com/matter-labs/zksync-era)) into `zksync_protobuf` ([era-consensus](https://github.com/matter-labs/era-consensus)). This PR just adds them to the new location.   

* trait `ProtoRepr`
* fn `read_required_repr`
* fn `encode<P: ProtoRepr>`
* fn `decode<P: ProtoRepr>`
* trait `RandomValue`
* struct `GenValue`


## Why ❔

To make them usable as a shared utility. 