### PR TITLE
Broadcast validators signature and collect QC [BFT-414]

### DIFF
--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -144,11 +144,16 @@ message NetAddress {
   optional std.Timestamp timestamp = 3; // required
 }
 
+message L1BatchSignature {
+  optional bytes signature = 1; // required
+}
+
 message Msg {
   oneof t { // required
     ConsensusMsg consensus = 1;
     bytes session_id = 2;
     NetAddress net_address = 3;
+    L1BatchSignature l1_batch_signature = 4;
   }
 }
 

--- a/node/libs/roles/src/validator/messages/l1_batch_signature.rs
+++ b/node/libs/roles/src/validator/messages/l1_batch_signature.rs
@@ -1,0 +1,6 @@
+use crate::validator::Signature;
+
+/// A message to send by validators to the gossip network.
+/// It contains the validators signature to sign the block batches to be sent to L1.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct L1BatchSignature(pub Signature);

--- a/node/libs/roles/src/validator/messages/mod.rs
+++ b/node/libs/roles/src/validator/messages/mod.rs
@@ -3,6 +3,7 @@
 mod block;
 mod consensus;
 mod discovery;
+mod l1_batch_signature;
 mod leader_commit;
 mod leader_prepare;
 mod msg;
@@ -12,6 +13,7 @@ mod replica_prepare;
 pub use block::*;
 pub use consensus::*;
 pub use discovery::*;
+pub use l1_batch_signature::*;
 pub use leader_commit::*;
 pub use leader_prepare::*;
 pub use msg::*;

--- a/node/libs/roles/src/validator/messages/msg.rs
+++ b/node/libs/roles/src/validator/messages/msg.rs
@@ -1,6 +1,9 @@
 //! Generic message types.
-use super::{ConsensusMsg, NetAddress};
-use crate::{node::SessionId, validator, validator::Error};
+use super::{ConsensusMsg, L1BatchSignature, NetAddress};
+use crate::{
+    node::SessionId,
+    validator::{self, Error},
+};
 use std::fmt;
 use zksync_consensus_crypto::{keccak256, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::{BadVariantError, Variant};
@@ -14,6 +17,8 @@ pub enum Msg {
     SessionId(SessionId),
     /// validator discovery
     NetAddress(NetAddress),
+    /// l1 batch signature
+    L1BatchSignature(L1BatchSignature),
 }
 
 impl Msg {
@@ -53,6 +58,18 @@ impl Variant<Msg> for NetAddress {
     }
     fn extract(msg: Msg) -> Result<Self, BadVariantError> {
         let Msg::NetAddress(this) = msg else {
+            return Err(BadVariantError);
+        };
+        Ok(this)
+    }
+}
+
+impl Variant<Msg> for L1BatchSignature {
+    fn insert(self) -> Msg {
+        Msg::L1BatchSignature(self)
+    }
+    fn extract(msg: Msg) -> Result<Self, BadVariantError> {
+        let Msg::L1BatchSignature(this) = msg else {
             return Err(BadVariantError);
         };
         Ok(this)


### PR DESCRIPTION
## What ❔

Implement a mechanism for validators to broadcast their signatures to other nodes in the network and collect them in a new certificate.

## Why ❔

This is essential for signing L1 batches and sending them to L1 for verification. Validators need to broadcast their signatures and gather them in a certificate in case the majority signs the new batch.
