### PR TITLE
Adds validity checks to BLS public keys

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "assert_matches"
@@ -163,20 +163,20 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backoff"
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -249,7 +249,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -266,9 +266,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitmaps"
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -332,9 +332,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bzip2-sys"
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -488,14 +488,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff_ce"
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "fixedbitset"
@@ -943,7 +943,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1021,9 +1021,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1063,6 +1063,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1232,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1527,7 +1533,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1602,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1628,7 +1634,7 @@ checksum = "adf157a4dc5a29b7b464aa8fe7edeff30076e07e13646a1c3874f58477dc99f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1673,7 +1679,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1730,7 +1736,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1887,7 +1893,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pairing_ce"
 version = "0.28.5"
-source = "git+https://github.com/matter-labs/pairing.git?rev=e47fd140a1fbfe99b740cabf3d1336127b59199c#e47fd140a1fbfe99b740cabf3d1336127b59199c"
+source = "git+https://github.com/matter-labs/pairing.git?rev=d24f2c5871089c4cd4f54c0ca266bb9fef6115eb#d24f2c5871089c4cd4f54c0ca266bb9fef6115eb"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -1972,7 +1978,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2013,7 +2019,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2125,19 +2131,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2162,7 +2168,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2182,7 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -2192,7 +2198,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.52",
+ "syn 2.0.55",
  "tempfile",
  "which",
 ]
@@ -2207,7 +2213,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2349,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2387,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2483,11 +2489,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2667,7 +2673,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2694,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2793,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snow"
@@ -2892,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2930,7 +2936,7 @@ checksum = "f9b53c7124dd88026d5d98a1eb1fd062a578b7d783017c9298825526c7fb6427"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2949,22 +2955,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3067,7 +3073,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3082,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3131,7 +3137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3177,7 +3183,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3285,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -3362,7 +3368,7 @@ source = "git+https://github.com/matter-labs/vise.git?rev=1c9cc500e92cf9ea052b23
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3411,7 +3417,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -3433,7 +3439,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3661,7 +3667,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3681,7 +3687,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3917,14 +3923,14 @@ name = "zksync_protobuf_build"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.4.1",
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-reflect",
  "protox",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -2689,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -3923,7 +3923,7 @@ name = "zksync_protobuf_build"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "heck 0.4.1",
+ "heck 0.5.0",
  "prettyplease",
  "proc-macro2",
  "prost-build",

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -1887,7 +1887,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pairing_ce"
 version = "0.28.5"
-source = "git+https://github.com/matter-labs/pairing.git?rev=f55393fd366596eac792d78525d26e9c4d6ed1ca#f55393fd366596eac792d78525d26e9c4d6ed1ca"
+source = "git+https://github.com/matter-labs/pairing.git?rev=e47fd140a1fbfe99b740cabf3d1336127b59199c#e47fd140a1fbfe99b740cabf3d1336127b59199c"
 dependencies = [
  "byteorder",
  "cfg-if",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -54,7 +54,7 @@ clap = { version = "4.3.3", features = ["derive"] }
 criterion = "0.5.1"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 ff_ce = "0.14.3"
-heck = "0.4.1"
+heck = "0.5.0"
 hex = "0.4.3"
 im = "15.1.0"
 once_cell = "1.17.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,7 +40,7 @@ zksync_protobuf = { path = "libs/protobuf" }
 zksync_protobuf_build = { path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
-pairing = { package = "pairing_ce", git = "https://github.com/matter-labs/pairing.git", rev = "f55393fd366596eac792d78525d26e9c4d6ed1ca" }
+pairing = { package = "pairing_ce", git = "https://github.com/matter-labs/pairing.git", rev = "e47fd140a1fbfe99b740cabf3d1336127b59199c" }
 vise = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
 vise-exporter = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
 
@@ -117,11 +117,9 @@ opt-level = 3
 
 [workspace.lints.rust]
 unsafe_code = "deny"
-noop_method_call = "warn"
 missing_docs = "warn"
 unreachable_pub = "warn"
 unused_qualifications = "warn"
-unused_tuple_struct_fields = "warn"
 
 [workspace.lints.clippy]
 # restriction group

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,7 +40,7 @@ zksync_protobuf = { path = "libs/protobuf" }
 zksync_protobuf_build = { path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
-pairing = { package = "pairing_ce", git = "https://github.com/matter-labs/pairing.git", rev = "e47fd140a1fbfe99b740cabf3d1336127b59199c" }
+pairing = { package = "pairing_ce", git = "https://github.com/matter-labs/pairing.git", rev = "d24f2c5871089c4cd4f54c0ca266bb9fef6115eb" }
 vise = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
 vise-exporter = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
 

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -37,7 +37,7 @@ pub(crate) enum Error {
     NotLeaderInView,
     /// Invalid message.
     #[error("invalid message: {0:#}")]
-    InvalidMessage(anyhow::Error),
+    InvalidMessage(#[source] anyhow::Error),
     /// Duplicate message from a replica.
     #[error("duplicate message from a replica (existing message: {existing_message:?}")]
     DuplicateMessage {
@@ -46,7 +46,7 @@ pub(crate) enum Error {
     },
     /// Invalid message signature.
     #[error("invalid signature: {0:#}")]
-    InvalidSignature(#[source] validator::Error),
+    InvalidSignature(#[source] anyhow::Error),
 }
 
 impl StateMachine {

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -40,7 +40,7 @@ pub(crate) enum Error {
     },
     /// Invalid message signature.
     #[error("invalid signature: {0:#}")]
-    InvalidSignature(#[source] validator::Error),
+    InvalidSignature(#[source] anyhow::Error),
     /// Invalid message.
     #[error(transparent)]
     InvalidMessage(validator::ReplicaPrepareVerifyError),

--- a/node/actors/bft/src/replica/leader_commit.rs
+++ b/node/actors/bft/src/replica/leader_commit.rs
@@ -33,7 +33,7 @@ pub(crate) enum Error {
     },
     /// Invalid message signature.
     #[error("invalid signature: {0:#}")]
-    InvalidSignature(validator::Error),
+    InvalidSignature(#[source] anyhow::Error),
     /// Invalid message.
     #[error("invalid message: {0:#}")]
     InvalidMessage(validator::CommitQCVerifyError),

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -38,7 +38,7 @@ pub(crate) enum Error {
     },
     /// Invalid message signature.
     #[error("invalid signature: {0:#}")]
-    InvalidSignature(#[source] validator::Error),
+    InvalidSignature(#[source] anyhow::Error),
     /// Invalid message.
     #[error("invalid message: {0:#}")]
     InvalidMessage(#[source] validator::LeaderPrepareVerifyError),

--- a/node/actors/network/src/consensus/handshake/mod.rs
+++ b/node/actors/network/src/consensus/handshake/mod.rs
@@ -50,7 +50,7 @@ pub(super) enum Error {
     #[error("unexpected peer")]
     PeerMismatch,
     #[error("validator signature {0}")]
-    Signature(#[from] validator::Error),
+    Signature(#[from] anyhow::Error),
     #[error("stream {0}")]
     Stream(#[source] anyhow::Error),
 }

--- a/node/actors/sync_blocks/src/peers/events.rs
+++ b/node/actors/sync_blocks/src/peers/events.rs
@@ -4,7 +4,7 @@ use zksync_consensus_roles::{node, validator::BlockNumber};
 
 /// Events emitted by `PeerStates` actor. Only used for tests so far.
 #[derive(Debug)]
-#[allow(dead_code, unused_tuple_struct_fields)] // Variant fields are only read in tests
+#[allow(dead_code)] // Variant fields are only read in tests
 pub(super) enum PeerStateEvent {
     /// Node has successfully downloaded the specified block.
     GotBlock(BlockNumber),

--- a/node/deny.toml
+++ b/node/deny.toml
@@ -59,6 +59,7 @@ multiple-versions = "deny"
 skip = [
     # Old versions required by tempfile and prost-build.
     { name = "bitflags", version = "1.3.2" },
+    { name = "heck", version = "0.4.1" },
 
     # Old version required by tracing-subscriber.
     { name = "regex-automata", version = "0.1.10" },

--- a/node/libs/concurrency/src/testonly.rs
+++ b/node/libs/concurrency/src/testonly.rs
@@ -37,7 +37,7 @@ pub fn abort_on_panic() {
 
 /// Guard which has to be dropped before timeout is reached.
 /// Otherwise the test will panic.
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 #[must_use]
 pub struct TimeoutGuard(std::sync::mpsc::Sender<()>);
 

--- a/node/libs/crypto/src/bn254/error.rs
+++ b/node/libs/crypto/src/bn254/error.rs
@@ -6,8 +6,4 @@ pub enum Error {
     SignatureVerificationFailure,
     #[error("Aggregate signature verification failure")]
     AggregateSignatureVerificationFailure,
-    #[error("Public key can't be zero")]
-    InvalidPublicKeyZero,
-    #[error("Public key must be in the subgroup")]
-    InvalidPublicKeySubgroup,
 }

--- a/node/libs/crypto/src/bn254/error.rs
+++ b/node/libs/crypto/src/bn254/error.rs
@@ -1,9 +1,0 @@
-/// Error type for generating and interacting with bn254.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum Error {
-    #[error("Signature verification failure")]
-    SignatureVerificationFailure,
-    #[error("Aggregate signature verification failure")]
-    AggregateSignatureVerificationFailure,
-}

--- a/node/libs/crypto/src/bn254/error.rs
+++ b/node/libs/crypto/src/bn254/error.rs
@@ -6,4 +6,8 @@ pub enum Error {
     SignatureVerificationFailure,
     #[error("Aggregate signature verification failure")]
     AggregateSignatureVerificationFailure,
+    #[error("Public key can't be zero")]
+    InvalidPublicKeyZero,
+    #[error("Public key must be in the subgroup")]
+    InvalidPublicKeySubgroup,
 }

--- a/node/libs/crypto/src/bn254/mod.rs
+++ b/node/libs/crypto/src/bn254/mod.rs
@@ -152,11 +152,11 @@ impl Signature {
     /// This optimization is needed for ensuring that tests can run within a reasonable time frame.
     #[inline(never)]
     pub fn verify(&self, msg: &[u8], pk: &PublicKey) -> Result<(), Error> {
-        let hash_point = hash::hash_to_g1(msg);
-
         // Verify public key is valid. Since we already check the validity of a
         // public key when constructing it, this should never fail (in theory).
         assert!(pk.is_valid());
+
+        let hash_point = hash::hash_to_g1(msg);
 
         // First pair: e(H(m): G1, pk: G2)
         let a = Bn256::pairing(hash_point, pk.0);

--- a/node/libs/crypto/src/bn254/mod.rs
+++ b/node/libs/crypto/src/bn254/mod.rs
@@ -99,11 +99,11 @@ impl ByteFmt for PublicKey {
         let p = G2Compressed::from_fixed_bytes(arr).into_affine()?;
 
         if p.is_zero() {
-            return Err(Error::InvalidPublicKeyZero.into());
+            anyhow::bail!("Public key can't be zero")
         }
 
         if p.scale_by_cofactor().is_zero() {
-            return Err(Error::InvalidPublicKeySubgroup.into());
+            anyhow::bail!("Public key must be in the subgroup")
         }
 
         Ok(PublicKey(p.into_projective()))
@@ -139,13 +139,14 @@ impl Signature {
     pub fn verify(&self, msg: &[u8], pk: &PublicKey) -> Result<(), Error> {
         let hash_point = hash::hash_to_g1(msg);
 
-        // Verify public key
+        // Verify public key. Since we already check the validity of a
+        // public key when constructing it, this should never fail (in theory).
         if pk.0.is_zero() {
-            return Err(Error::InvalidPublicKeyZero);
+            unreachable!();
         }
 
         if pk.0.into_affine().scale_by_cofactor().is_zero() {
-            return Err(Error::InvalidPublicKeySubgroup);
+            unreachable!();
         }
 
         // First pair: e(H(m): G1, pk: G2)

--- a/node/libs/crypto/src/bn254/tests.rs
+++ b/node/libs/crypto/src/bn254/tests.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ff_ce::PrimeField;
 use pairing::{
-    bn256::{Fr, G2Affine},
+    bn256::{Fr, G2Affine, G2},
     CurveAffine, CurveProjective,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -122,8 +122,8 @@ fn byte_fmt_correctness() {
 #[test]
 fn pk_is_valid_correctness() {
     // Check that the null point is invalid.
-    let mut pk = PublicKey::default();
-    assert!(!pk.is_valid());
+    let mut pk = PublicKey(G2::zero());
+    assert!(pk.verify().is_err());
 
     // Check that a point in the wrong subgroup is invalid.
     let mut rng = rand04::OsRng::new().unwrap();
@@ -147,5 +147,5 @@ fn pk_is_valid_correctness() {
         }
     }
 
-    assert!(!pk.is_valid());
+    assert!(pk.verify().is_err());
 }

--- a/node/libs/crypto/src/bn254/tests.rs
+++ b/node/libs/crypto/src/bn254/tests.rs
@@ -90,6 +90,18 @@ fn aggregate_signature_failure_smoke() {
 }
 
 #[test]
+fn pk_validity_checks() {
+    // Check that we can't decode the null point.
+    let pk = PublicKey::default();
+    let bytes = pk.encode();
+    let pk_decoded = PublicKey::decode(&bytes);
+    let err = pk_decoded.unwrap_err();
+    assert_eq!(format!("{}", err.root_cause()), "Public key can't be zero");
+
+    // TODO: Create a G2 point in the wrong subgroup and test against it.
+}
+
+#[test]
 fn byte_fmt_correctness() {
     let mut rng = rand::thread_rng();
 

--- a/node/libs/roles/src/validator/keys/aggregate_signature.rs
+++ b/node/libs/roles/src/validator/keys/aggregate_signature.rs
@@ -1,4 +1,4 @@
-use super::{Error, PublicKey, Signature};
+use super::{PublicKey, Signature};
 use crate::validator::messages::{Msg, MsgHash};
 use std::fmt;
 use zksync_consensus_crypto::{bn254, ByteFmt, Text, TextFmt};
@@ -18,7 +18,7 @@ impl AggregateSignature {
     pub(crate) fn verify_messages<'a, V: Variant<Msg>>(
         &self,
         messages_and_keys: impl Iterator<Item = (V, &'a PublicKey)>,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         let hashes_and_keys =
             messages_and_keys.map(|(message, key)| (message.insert().hash(), key));
         self.verify_hash(hashes_and_keys)
@@ -28,7 +28,7 @@ impl AggregateSignature {
     pub(crate) fn verify_hash<'a>(
         &self,
         hashes_and_keys: impl Iterator<Item = (MsgHash, &'a PublicKey)>,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         let bytes_and_pks: Vec<_> = hashes_and_keys
             .map(|(hash, pk)| (hash.0.as_bytes().to_owned(), &pk.0))
             .collect();

--- a/node/libs/roles/src/validator/keys/mod.rs
+++ b/node/libs/roles/src/validator/keys/mod.rs
@@ -9,6 +9,3 @@ pub use aggregate_signature::AggregateSignature;
 pub use public_key::PublicKey;
 pub use secret_key::SecretKey;
 pub use signature::Signature;
-
-/// Error type returned by validator key operations.
-pub type Error = zksync_consensus_crypto::bn254::Error;

--- a/node/libs/roles/src/validator/keys/signature.rs
+++ b/node/libs/roles/src/validator/keys/signature.rs
@@ -1,4 +1,4 @@
-use super::{Error, PublicKey};
+use super::PublicKey;
 use crate::validator::messages::{Msg, MsgHash};
 use std::fmt;
 use zksync_consensus_crypto::{bn254, ByteFmt, Text, TextFmt};
@@ -9,12 +9,12 @@ pub struct Signature(pub(crate) bn254::Signature);
 
 impl Signature {
     /// Verify a message against a public key.
-    pub fn verify_msg(&self, msg: &Msg, pk: &PublicKey) -> Result<(), Error> {
+    pub fn verify_msg(&self, msg: &Msg, pk: &PublicKey) -> anyhow::Result<()> {
         self.verify_hash(&msg.hash(), pk)
     }
 
     /// Verify a message hash against a public key.
-    pub fn verify_hash(&self, msg_hash: &MsgHash, pk: &PublicKey) -> Result<(), Error> {
+    pub fn verify_hash(&self, msg_hash: &MsgHash, pk: &PublicKey) -> anyhow::Result<()> {
         self.0.verify(&ByteFmt::encode(msg_hash), &pk.0)
     }
 }

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -51,7 +51,7 @@ pub enum CommitQCVerifyError {
     },
     /// Bad signature.
     #[error("bad signature: {0:#}")]
-    BadSignature(#[source] validator::Error),
+    BadSignature(#[source] anyhow::Error),
 }
 
 impl CommitQC {

--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -40,7 +40,7 @@ pub enum PrepareQCVerifyError {
     },
     /// Bad signature.
     #[error("bad signature: {0:#}")]
-    BadSignature(validator::Error),
+    BadSignature(#[source] anyhow::Error),
 }
 
 impl PrepareQC {

--- a/node/libs/roles/src/validator/messages/msg.rs
+++ b/node/libs/roles/src/validator/messages/msg.rs
@@ -1,6 +1,6 @@
 //! Generic message types.
 use super::{ConsensusMsg, NetAddress};
-use crate::{node::SessionId, validator, validator::Error};
+use crate::{node::SessionId, validator};
 use std::fmt;
 use zksync_consensus_crypto::{keccak256, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::{BadVariantError, Variant};
@@ -108,7 +108,7 @@ pub struct Signed<V: Variant<Msg>> {
 
 impl<V: Variant<Msg> + Clone> Signed<V> {
     /// Verify the signature on the message.
-    pub fn verify(&self) -> Result<(), Error> {
+    pub fn verify(&self) -> anyhow::Result<()> {
         self.sig.verify_msg(&self.msg.clone().insert(), &self.key)
     }
 }


### PR DESCRIPTION
## What ❔

Added checks for the validity of our BLS public keys as recommended by this [spec](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html). Namely we check that the public key is not zero and that it is in the correct subgroup.

We do it redundantly in two places (when we decode a public key and when we verify a signature).

## Why ❔

Invalid public keys are a security risk.
