### PR TITLE
Made view timeout computation saturating.

### DIFF
--- a/node/actors/bft/src/metrics.rs
+++ b/node/actors/bft/src/metrics.rs
@@ -70,6 +70,8 @@ pub(crate) struct ConsensusMetrics {
     pub(crate) leader_processing_latency: Family<ProcessingLatencyLabels, Histogram<Duration>>,
     /// Number of the last finalized block observed by the node.
     pub(crate) finalized_block_number: Gauge<u64>,
+    #[metrics(unit = Unit::Seconds)]
+    pub(crate) replica_view_number: Gauge<u64>,
 }
 
 /// Global instance of [`ConsensusMetrics`].

--- a/node/actors/bft/src/replica/timer.rs
+++ b/node/actors/bft/src/replica/timer.rs
@@ -7,6 +7,10 @@ use zksync_consensus_roles::validator;
 impl StateMachine {
     /// The base duration of the timeout.
     pub(crate) const BASE_DURATION: time::Duration = time::Duration::milliseconds(2000);
+    /// Max duration of the timeout.
+    /// Consensus is unusable with this range of timeout anyway,
+    /// however to make debugging easier we bound it to a specific value.
+    pub(crate) const MAX_DURATION: time::Duration = time::Duration::seconds(1000000);
 
     /// Resets the timer. On every timeout we double the duration, starting from a given base duration.
     /// This is a simple exponential backoff.
@@ -16,7 +20,16 @@ impl StateMachine {
             Some(qc) => qc.view().number.next(),
             None => validator::ViewNumber(0),
         };
-        let timeout = Self::BASE_DURATION * 2u32.pow((self.view.0 - final_view.0) as u32);
+        let f = self
+            .view
+            .0
+            .saturating_sub(final_view.0)
+            .try_into()
+            .unwrap_or(u32::MAX);
+        let f = 2u64.saturating_pow(f).try_into().unwrap_or(i32::MAX);
+        let timeout = Self::BASE_DURATION
+            .saturating_mul(f)
+            .min(Self::MAX_DURATION);
 
         metrics::METRICS.replica_view_timeout.set_latency(timeout);
         self.timeout_deadline = time::Deadline::Finite(ctx.now() + timeout);

--- a/node/actors/network/src/consensus/tests.rs
+++ b/node/actors/network/src/consensus/tests.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::{io, metrics, preface, rpc, testonly};
 use assert_matches::assert_matches;
 use rand::Rng;
-use tracing::Instrument as _;
 use zksync_concurrency::{ctx, net, scope, testonly::abort_on_panic};
 use zksync_consensus_roles::validator;
 use zksync_consensus_storage::testonly::new_store;

--- a/node/actors/network/src/metrics.rs
+++ b/node/actors/network/src/metrics.rs
@@ -56,6 +56,13 @@ impl MeteredStream {
     }
 }
 
+impl std::ops::Deref for MeteredStream {
+    type Target = net::tcp::Stream;
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
 impl io::AsyncRead for MeteredStream {
     #[inline(always)]
     fn poll_read(

--- a/node/actors/network/src/noise/stream.rs
+++ b/node/actors/network/src/noise/stream.rs
@@ -87,6 +87,13 @@ pub(crate) struct Stream<S = MeteredStream> {
     write_buf: Box<Buffer>,
 }
 
+impl<S> std::ops::Deref for Stream<S> {
+    type Target = S;
+    fn deref(&self) -> &S {
+        &self.inner
+    }
+}
+
 impl<S> Stream<S>
 where
     S: io::AsyncRead + io::AsyncWrite + Unpin,

--- a/node/libs/crypto/src/bls12_381/testonly.rs
+++ b/node/libs/crypto/src/bls12_381/testonly.rs
@@ -1,12 +1,12 @@
 //! Random key generation, intended for use in testing
 
-use super::{AggregateSignature, PublicKey, SecretKey, Signature};
+use super::{bls, AggregateSignature, PublicKey, SecretKey, Signature};
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
 /// Generates a random SecretKey. This is meant for testing purposes.
 impl Distribution<SecretKey> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SecretKey {
-        SecretKey::generate(rng.gen())
+        SecretKey(bls::SecretKey::key_gen_v4_5(&rng.gen::<[u8; 32]>(), &[], &[]).unwrap())
     }
 }
 

--- a/node/libs/crypto/src/bls12_381/tests.rs
+++ b/node/libs/crypto/src/bls12_381/tests.rs
@@ -1,19 +1,15 @@
 use super::*;
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::iter::repeat_with;
 
 // Test signing and verifying a random message
 #[test]
 fn signature_smoke() {
     let mut rng = StdRng::seed_from_u64(29483920);
 
-    let sk = SecretKey::generate(rng.gen());
-    let pk = sk.public();
+    let sk: SecretKey = rng.gen();
     let msg: [u8; 32] = rng.gen();
-
     let sig = sk.sign(&msg);
-
-    sig.verify(&msg, &pk).unwrap()
+    sig.verify(&msg, &sk.public()).unwrap()
 }
 
 #[test]
@@ -27,14 +23,11 @@ fn infinity_public_key_failure() {
 fn signature_failure_smoke() {
     let mut rng = StdRng::seed_from_u64(29483920);
 
-    let sk1 = SecretKey::generate(rng.gen());
-    let sk2 = SecretKey::generate(rng.gen());
-    let pk2 = sk2.public();
+    let sk1: SecretKey = rng.gen();
+    let sk2: SecretKey = rng.gen();
     let msg: [u8; 32] = rng.gen();
-
     let sig = sk1.sign(&msg);
-
-    assert!(sig.verify(&msg, &pk2).is_err())
+    assert!(sig.verify(&msg, &sk2.public()).is_err())
 }
 
 // Test signing and verifying a random message using aggregate signatures
@@ -43,9 +36,7 @@ fn aggregate_signature_smoke() {
     let mut rng = StdRng::seed_from_u64(29483920);
 
     // Use an arbitrary 5 keys for the smoke test
-    let sks: Vec<SecretKey> = repeat_with(|| SecretKey::generate(rng.gen()))
-        .take(5)
-        .collect();
+    let sks: Vec<SecretKey> = (0..5).map(|_| rng.gen()).collect();
     let pks: Vec<PublicKey> = sks.iter().map(|k| k.public()).collect();
     let msg: [u8; 32] = rng.gen();
 
@@ -61,9 +52,7 @@ fn aggregate_signature_failure_smoke() {
     let mut rng = StdRng::seed_from_u64(29483920);
 
     // Use an arbitrary 5 keys for the smoke test
-    let sks: Vec<SecretKey> = repeat_with(|| SecretKey::generate(rng.gen()))
-        .take(5)
-        .collect();
+    let sks: Vec<SecretKey> = (0..5).map(|_| rng.gen()).collect();
     let pks: Vec<PublicKey> = sks.iter().map(|k| k.public()).collect();
     let msg: [u8; 32] = rng.gen();
 

--- a/node/libs/crypto/src/ed25519/mod.rs
+++ b/node/libs/crypto/src/ed25519/mod.rs
@@ -17,7 +17,7 @@ pub struct SecretKey(ed::SigningKey);
 impl SecretKey {
     /// Generates a secret key from a cryptographically-secure entropy source.
     pub fn generate() -> Self {
-        Self(ed::SigningKey::generate(&mut rand::rngs::OsRng {}))
+        Self(ed::SigningKey::generate(&mut rand::rngs::OsRng))
     }
 
     /// Signs a message.

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -362,6 +362,12 @@ impl ViewNumber {
     }
 }
 
+impl fmt::Display for ViewNumber {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
 /// An enum that represents the current phase of the consensus.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
The current version was overflowing quite fast. It might have been the cause why consensus component is broken on stage right now. Additionally I've added some more debugging info and view_number metric. Unrelated: for consistency, I've hardcoded the secret key constructor for bls to use good entropy source.