### PR TITLE
Bumped protocol version

### DIFF
--- a/node/actors/bft/src/lib.rs
+++ b/node/actors/bft/src/lib.rs
@@ -32,7 +32,7 @@ pub mod testonly;
 mod tests;
 
 /// Protocol version of this BFT implementation.
-pub const PROTOCOL_VERSION: validator::ProtocolVersion = validator::ProtocolVersion::EARLIEST;
+pub const PROTOCOL_VERSION: validator::ProtocolVersion = validator::ProtocolVersion::CURRENT;
 
 /// Payload proposal and verification trait.
 #[async_trait::async_trait]

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -16,8 +16,9 @@ use zksync_consensus_utils::enum_util::{BadVariantError, Variant};
 pub struct ProtocolVersion(pub u32);
 
 impl ProtocolVersion {
-    /// Earliest protocol version.
-    pub const EARLIEST: Self = Self(0);
+    /// 0 - development version; deprecated.
+    /// 1 - development version
+    pub const CURRENT: Self = Self(1);
 
     /// Returns the integer corresponding to this version.
     pub fn as_u32(self) -> u32 {

--- a/node/libs/roles/src/validator/messages/mod.rs
+++ b/node/libs/roles/src/validator/messages/mod.rs
@@ -8,6 +8,8 @@ mod leader_prepare;
 mod msg;
 mod replica_commit;
 mod replica_prepare;
+#[cfg(test)]
+mod tests;
 
 pub use block::*;
 pub use consensus::*;

--- a/node/libs/roles/src/validator/messages/tests.rs
+++ b/node/libs/roles/src/validator/messages/tests.rs
@@ -65,6 +65,21 @@ mod version1 {
     const VERSION: ProtocolVersion = ProtocolVersion(1);
     use super::*;
 
+    /// asserts that msg.hash()==hash and that sig is a
+    /// valid signature of msg (signed by `keys()[0]`).
+    #[track_caller]
+    fn change_detector(msg: Msg, hash: &str, sig: &str) {
+        let hash: MsgHash = Text::new(hash).decode().unwrap();
+        assert!(hash == msg.hash(), "bad hash, want {:?}", msg.hash());
+        let sig: Signature = Text::new(sig).decode().unwrap();
+        let key = keys()[0].clone();
+        assert!(
+            sig.verify_hash(&hash, &key.public()).is_ok(),
+            "bad signature, want {:?}",
+            key.sign_hash(&hash),
+        );
+    }
+
     /// Hardcoded view.
     fn view() -> View {
         View {
@@ -139,33 +154,37 @@ mod version1 {
 
     #[test]
     fn replica_commit_change_detector() {
-        let want: MsgHash = Text::new("validator_msg:keccak256:3538aa25b136b1ec7a8c9f8ac660b2cfabf06a6af35620c6d06c48200a6e43d4").decode().unwrap();
-        assert_eq!(want, replica_commit().insert().hash());
-        let sig: Signature = Text::new("validator:signature:bn254:acf1d30e191be77f7d49ae959403b650cb8d2be6472d0296b31912d63ae74ea9").decode().unwrap();
-        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+        change_detector(
+            replica_commit().insert(),
+            "validator_msg:keccak256:bc629a46e67d0ceef09f898afe7c773b010f78f474452226364deb12f26bff59",
+            "validator:signature:bn254:09dca52611cf60eba99293a1ffec853ba65370b5c6727c5009748f7f59fefabd",
+        );
     }
 
     #[test]
     fn leader_commit_change_detector() {
-        let want: MsgHash = Text::new("validator_msg:keccak256:f17469f8ab95ae08c5bb383ccdceb9b685cb4c8fc6e75b7eefef7ea5c419e386").decode().unwrap();
-        assert_eq!(want, leader_commit().insert().hash());
-        let sig: Signature = Text::new("validator:signature:bn254:8663ff8f097e51d259f41450652fc936890d9a3592de07c5f81c0be57cb301cd").decode().unwrap();
-        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+        change_detector(
+            leader_commit().insert(),
+            "validator_msg:keccak256:340c4f1d075d070a8bbde198c777f89e3c025b8e14e1d32328a52b694d7fb7da",
+            "validator:signature:bn254:08729ad003eee453696b72e56d2a75124730ff17376fca7099a21f32ff1b265a",
+        );
     }
 
     #[test]
     fn replica_prepare_change_detector() {
-        let want : MsgHash = Text::new("validator_msg:keccak256:2f3da9f4ad132e333a383bf97aa8c0c82fd302289b33f6f57e9bcd1a53b0b75d").decode().unwrap();
-        assert_eq!(want, replica_prepare().insert().hash());
-        let sig: Signature = Text::new("validator:signature:bn254:9a2f2f3a56ac385d8b3e5fb3db563d6785bffc9a73f2babe858d24233098f723").decode().unwrap();
-        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+        change_detector(
+            replica_prepare().insert(),
+            "validator_msg:keccak256:361382ac2738d16f2b013f8674550970b8a5d79ab92eb1a437df2e478a0bbf46",
+            "validator:signature:bn254:8bd0a2f83e7fc0321a9d487266ca3e7ad4f717f8bf314ce1bb858f7235f84914",
+        );
     }
 
     #[test]
     fn leader_prepare_change_detector() {
-        let want : MsgHash = Text::new("validator_msg:keccak256:2a8389574a692a48525c43b5a9a444da7bade1b4b4d95ccec7d9fb3d731a7428").decode().unwrap();
-        assert_eq!(want, leader_prepare().insert().hash());
-        let sig: Signature = Text::new("validator:signature:bn254:065c45ecee3d7363b09f17b3dff610ff33a98d0ea0a90b8dd364fde48660bffc").decode().unwrap();
-        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+        change_detector(
+            leader_prepare().insert(),
+            "validator_msg:keccak256:e29ae451d7bd6a72e1cccb5666fb66ddbd893e506d91e1985e9723a65bd9298b",
+            "validator:signature:bn254:92a42139359540383f90f01f7f69907a4f4e04f1753ffd857266ed4c157f7fa9",
+        );
     }
 }

--- a/node/libs/roles/src/validator/messages/tests.rs
+++ b/node/libs/roles/src/validator/messages/tests.rs
@@ -1,0 +1,171 @@
+use crate::validator::*;
+use zksync_consensus_crypto::Text;
+use zksync_consensus_utils::enum_util::Variant as _;
+
+/// Hardcoded secret keys.
+fn keys() -> Vec<SecretKey> {
+    [
+        "validator:secret:bn254:27cb45b1670a1ae8d376a85821d51c7f91ebc6e32788027a84758441aaf0a987",
+        "validator:secret:bn254:20132edc08a529e927f155e710ae7295a2a0d249f1b1f37726894d1d0d8f0d81",
+        "validator:secret:bn254:0946901f0a6650284726763b12de5da0f06df0016c8ec2144cf6b1903f1979a6",
+    ]
+    .iter()
+    .map(|raw| Text::new(raw).decode().unwrap())
+    .collect()
+}
+
+/// Hardcoded payload.
+fn payload() -> Payload {
+    Payload(
+        hex::decode("57b79660558f18d56b5196053f64007030a1cb7eeadb5c32d816b9439f77edf5f6bd9d")
+            .unwrap(),
+    )
+}
+
+/// Hardcoded fork.
+fn fork() -> Fork {
+    Fork {
+        number: ForkNumber(402598740274745173),
+        first_block: BlockNumber(8902834932452),
+    }
+}
+
+/// Hardcoded genesis.
+fn genesis() -> Genesis {
+    Genesis {
+        validators: ValidatorSet::new(keys().iter().map(|k| k.public())).unwrap(),
+        fork: fork(),
+    }
+}
+
+#[test]
+fn payload_hash_change_detector() {
+    let want: PayloadHash = Text::new(
+        "payload:keccak256:ba8ffff2526cae27a9e8e014749014b08b80e01905c8b769159d02d6579d9b83",
+    )
+    .decode()
+    .unwrap();
+    assert_eq!(want, payload().hash());
+}
+
+/// Note that genesis is NOT versioned by ProtocolVersion.
+/// Even if it was, ALL versions of genesis need to be supported FOREVER,
+/// unless we introduce dynamic regenesis.
+#[test]
+fn genesis_hash_change_detector() {
+    let want: GenesisHash = Text::new(
+        "genesis_hash:keccak256:9c9bfa303e8d2d451a7fadd327f5f1b957a37c84d7b27b9e1cf7b92fd83af7ae",
+    )
+    .decode()
+    .unwrap();
+    assert_eq!(want, genesis().hash());
+}
+
+mod version1 {
+    const VERSION: ProtocolVersion = ProtocolVersion(1);
+    use super::*;
+
+    /// Hardcoded view.
+    fn view() -> View {
+        View {
+            protocol_version: VERSION,
+            number: ViewNumber(9136573498460759103),
+            fork: fork().number,
+        }
+    }
+
+    /// Hardcoded `BlockHeader`.
+    fn block_header() -> BlockHeader {
+        BlockHeader {
+            number: BlockNumber(772839452345),
+            payload: payload().hash(),
+        }
+    }
+
+    /// Hardcoded `ReplicaCommit`.
+    fn replica_commit() -> ReplicaCommit {
+        ReplicaCommit {
+            view: view(),
+            proposal: block_header(),
+        }
+    }
+
+    /// Hardcoded `CommitQC`.
+    fn commit_qc() -> CommitQC {
+        let genesis = genesis();
+        let replica_commit = replica_commit();
+        let mut x = CommitQC::new(replica_commit.clone(), &genesis);
+        for k in keys() {
+            x.add(&k.sign_msg(replica_commit.clone()), &genesis);
+        }
+        x
+    }
+
+    /// Hardcoded `LeaderCommit`.
+    fn leader_commit() -> LeaderCommit {
+        LeaderCommit {
+            justification: commit_qc(),
+        }
+    }
+
+    /// Hardcoded `ReplicaPrepare`
+    fn replica_prepare() -> ReplicaPrepare {
+        ReplicaPrepare {
+            view: view(),
+            high_vote: Some(replica_commit()),
+            high_qc: Some(commit_qc()),
+        }
+    }
+
+    /// Hardcoded `PrepareQC`.
+    fn prepare_qc() -> PrepareQC {
+        let mut x = PrepareQC::new(view());
+        let genesis = genesis();
+        let replica_prepare = replica_prepare();
+        for k in keys() {
+            x.add(&k.sign_msg(replica_prepare.clone()), &genesis);
+        }
+        x
+    }
+
+    /// Hardcoded `LeaderPrepare`.
+    fn leader_prepare() -> LeaderPrepare {
+        LeaderPrepare {
+            proposal: block_header(),
+            proposal_payload: Some(payload()),
+            justification: prepare_qc(),
+        }
+    }
+
+    #[test]
+    fn replica_commit_change_detector() {
+        let want: MsgHash = Text::new("validator_msg:keccak256:3538aa25b136b1ec7a8c9f8ac660b2cfabf06a6af35620c6d06c48200a6e43d4").decode().unwrap();
+        assert_eq!(want, replica_commit().insert().hash());
+        let sig: Signature = Text::new("validator:signature:bn254:acf1d30e191be77f7d49ae959403b650cb8d2be6472d0296b31912d63ae74ea9").decode().unwrap();
+        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+    }
+
+    #[test]
+    fn leader_commit_change_detector() {
+        let want: MsgHash = Text::new("validator_msg:keccak256:f17469f8ab95ae08c5bb383ccdceb9b685cb4c8fc6e75b7eefef7ea5c419e386").decode().unwrap();
+        assert_eq!(want, leader_commit().insert().hash());
+        let sig: Signature = Text::new("validator:signature:bn254:8663ff8f097e51d259f41450652fc936890d9a3592de07c5f81c0be57cb301cd").decode().unwrap();
+        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+    }
+
+    #[test]
+    fn replica_prepare_change_detector() {
+        let want : MsgHash = Text::new("validator_msg:keccak256:2f3da9f4ad132e333a383bf97aa8c0c82fd302289b33f6f57e9bcd1a53b0b75d").decode().unwrap();
+        assert_eq!(want, replica_prepare().insert().hash());
+        let sig: Signature = Text::new("validator:signature:bn254:9a2f2f3a56ac385d8b3e5fb3db563d6785bffc9a73f2babe858d24233098f723").decode().unwrap();
+        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+    }
+
+    #[test]
+    fn leader_prepare_change_detector() {
+        let want : MsgHash = Text::new("validator_msg:keccak256:2a8389574a692a48525c43b5a9a444da7bade1b4b4d95ccec7d9fb3d731a7428").decode().unwrap();
+        assert_eq!(want, leader_prepare().insert().hash());
+        let sig: Signature = Text::new("validator:signature:bn254:065c45ecee3d7363b09f17b3dff610ff33a98d0ea0a90b8dd364fde48660bffc").decode().unwrap();
+        sig.verify_hash(&want, &keys()[0].public()).unwrap();
+    }
+}

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -53,7 +53,7 @@ impl Setup {
     /// Pushes the next block with the given payload.
     pub fn push_block(&mut self, payload: Payload) {
         let view = View {
-            protocol_version: ProtocolVersion::EARLIEST,
+            protocol_version: ProtocolVersion::CURRENT,
             fork: self.genesis.fork.number,
             number: self
                 .0

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -159,7 +159,7 @@ fn test_agg_signature_verify() {
 
 fn make_view(number: ViewNumber, setup: &Setup) -> View {
     View {
-        protocol_version: ProtocolVersion::EARLIEST,
+        protocol_version: ProtocolVersion::CURRENT,
         fork: setup.genesis.fork.number,
         number,
     }


### PR DESCRIPTION
Recent change of hash_to_point implementation is not backward compatible. I've bumped the protocol version and added tests so that in the future we won't introduce backward incompatible protocol changes to the crypto logic by accident. We are about to introduce several more backward incompatible changes, and they will also be included into the protocol version 1.