### PR TITLE
retransmission of consensus messages after reconnect

### DIFF
--- a/node/actors/network/src/consensus/mod.rs
+++ b/node/actors/network/src/consensus/mod.rs
@@ -147,7 +147,7 @@ impl rpc::Handler<rpc::consensus::Rpc> for &Network {
                 ack: send,
             }));
         // TODO(gprusak): disconnection means that there message was rejected OR
-        // that bft actor is missing (in tests), which leads to unnecesary disconnects.
+        // that bft actor is missing (in tests), which leads to unnecessary disconnects.
         let _ = recv.recv_or_disconnected(ctx).await?;
         Ok(rpc::consensus::Resp)
     }

--- a/node/actors/network/src/gossip/runner.rs
+++ b/node/actors/network/src/gossip/runner.rs
@@ -57,7 +57,7 @@ impl rpc::Handler<rpc::push_block_store_state::Rpc> for PushBlockStoreStateServe
         };
         self.net.sender.send(message.into());
         // TODO(gprusak): disconnection means that the message was rejected OR
-        // that `SyncBlocks` actor is missing (in tests), which leads to unnecesary disconnects.
+        // that `SyncBlocks` actor is missing (in tests), which leads to unnecessary disconnects.
         let _ = response_receiver.recv_or_disconnected(ctx).await?;
         Ok(())
     }

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -83,7 +83,7 @@ impl Network {
                     .as_ref()
                     .context("not a validator node")?
                     .msg_pool
-                    .send(message);
+                    .send(Arc::new(message));
             }
             io::InputMessage::SyncBlocks(io::SyncBlocksInputMessage::GetBlock {
                 recipient,

--- a/node/actors/network/src/rpc/mod.rs
+++ b/node/actors/network/src/rpc/mod.rs
@@ -104,7 +104,8 @@ impl<'a, R: Rpc> ReservedCall<'a, R> {
         let now = ctx.now();
         let metric_labels = CallLatencyType::ClientSendRecv.to_labels::<R>(req, &res);
         RPC_METRICS.latency[&metric_labels].observe_latency(now - send_time);
-        let (res, msg_size) = res.context(R::METHOD)?;
+        let (res, msg_size) =
+            res.with_context(|| format!("{}.{}", R::METHOD, R::submethod(req)))?;
         RPC_METRICS.message_size[&CallType::RespRecv.to_labels::<R>(req)].observe(msg_size);
         Ok(res)
     }

--- a/node/actors/network/src/testonly.rs
+++ b/node/actors/network/src/testonly.rs
@@ -1,7 +1,13 @@
 //! Testonly utilities.
 #![allow(dead_code)]
-use crate::{Config, GossipConfig, Network, RpcConfig, Runner};
-use rand::Rng;
+use crate::{
+    io::{ConsensusInputMessage, Target},
+    Config, GossipConfig, Network, RpcConfig, Runner,
+};
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -10,6 +16,24 @@ use zksync_concurrency::{ctx, ctx::channel, io, limiter, net, scope, sync};
 use zksync_consensus_roles::{node, validator};
 use zksync_consensus_storage::BlockStore;
 use zksync_consensus_utils::pipe;
+
+impl Distribution<Target> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Target {
+        match rng.gen_range(0..2) {
+            0 => Target::Broadcast,
+            _ => Target::Validator(rng.gen()),
+        }
+    }
+}
+
+impl Distribution<ConsensusInputMessage> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ConsensusInputMessage {
+        ConsensusInputMessage {
+            message: rng.gen(),
+            recipient: rng.gen(),
+        }
+    }
+}
 
 /// Synchronously forwards data from one stream to another.
 pub(crate) async fn forward(

--- a/node/libs/crypto/src/ed25519/tests.rs
+++ b/node/libs/crypto/src/ed25519/tests.rs
@@ -1,5 +1,7 @@
-use crate::ed25519::{PublicKey, SecretKey, Signature};
-use crate::ByteFmt;
+use crate::{
+    ed25519::{PublicKey, SecretKey, Signature},
+    ByteFmt,
+};
 
 #[test]
 fn test_ed25519() -> anyhow::Result<()> {

--- a/node/libs/roles/src/validator/messages/msg.rs
+++ b/node/libs/roles/src/validator/messages/msg.rs
@@ -60,7 +60,7 @@ impl Variant<Msg> for NetAddress {
 }
 
 /// Hash of a message.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MsgHash(pub(crate) keccak256::Keccak256);
 
 impl ByteFmt for MsgHash {


### PR DESCRIPTION
Implemented retransmission of consensus messages after reconnect. It should improve chances of finalizing blocks over a faulty network.