### PR TITLE
Support multiple leader-selection modes (BFT-416)

### DIFF
--- a/node/actors/network/src/gossip/tests.rs
+++ b/node/actors/network/src/gossip/tests.rs
@@ -14,7 +14,9 @@ use zksync_concurrency::{
     testonly::{abort_on_panic, set_timeout},
     time,
 };
-use zksync_consensus_roles::validator::{self, BlockNumber, FinalBlock, WeightedValidator};
+use zksync_consensus_roles::validator::{
+    self, BlockNumber, FinalBlock, LeaderSelectionMode, WeightedValidator,
+};
 use zksync_consensus_storage::testonly::new_store;
 
 #[tokio::test]
@@ -143,10 +145,13 @@ async fn test_validator_addrs() {
     let rng = &mut ctx::test_root(&ctx::RealClock).rng();
 
     let keys: Vec<validator::SecretKey> = (0..8).map(|_| rng.gen()).collect();
-    let validators = validator::Committee::new(keys.iter().map(|k| WeightedValidator {
-        key: k.public(),
-        weight: 1250,
-    }))
+    let validators = validator::Committee::new(
+        keys.iter().map(|k| WeightedValidator {
+            key: k.public(),
+            weight: 1250,
+        }),
+        LeaderSelectionMode::RoundRobin,
+    )
     .unwrap();
     let va = ValidatorAddrsWatch::default();
     let mut sub = va.subscribe();

--- a/node/libs/roles/src/validator/conv.rs
+++ b/node/libs/roles/src/validator/conv.rs
@@ -4,7 +4,7 @@ use super::{
     MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProtocolVersion, PublicKey,
     ReplicaCommit, ReplicaPrepare, Signature, Signed, Signers, View, ViewNumber, WeightedValidator,
 };
-use crate::{node::SessionId, proto::validator as proto};
+use crate::{node::SessionId, proto::validator as proto, validator::LeaderSelectionMode};
 use anyhow::Context as _;
 use std::collections::BTreeMap;
 use zksync_consensus_crypto::ByteFmt;
@@ -63,7 +63,8 @@ impl ProtoFmt for Genesis {
             };
         Ok(Self {
             fork: read_required(&r.fork).context("fork")?,
-            validators: Committee::new(validators.into_iter()).context("validators")?,
+            validators: Committee::new(validators.into_iter(), LeaderSelectionMode::RoundRobin)
+                .context("validators")?,
             version,
         })
     }

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -204,7 +204,11 @@ fn test_commit_qc() {
     let setup1 = Setup::new(rng, 6);
     let setup2 = Setup::new(rng, 6);
     let genesis3 = Genesis {
-        validators: Committee::new(setup1.genesis.validators.iter().take(3).cloned()).unwrap(),
+        validators: Committee::new(
+            setup1.genesis.validators.iter().take(3).cloned(),
+            LeaderSelectionMode::RoundRobin,
+        )
+        .unwrap(),
         fork: setup1.genesis.fork.clone(),
         ..Default::default()
     };
@@ -242,7 +246,11 @@ fn test_prepare_qc() {
     let setup1 = Setup::new(rng, 6);
     let setup2 = Setup::new(rng, 6);
     let genesis3 = Genesis {
-        validators: Committee::new(setup1.genesis.validators.iter().take(3).cloned()).unwrap(),
+        validators: Committee::new(
+            setup1.genesis.validators.iter().take(3).cloned(),
+            LeaderSelectionMode::RoundRobin,
+        )
+        .unwrap(),
         fork: setup1.genesis.fork.clone(),
         ..Default::default()
     };


### PR DESCRIPTION
### Built on top of https://github.com/matter-labs/era-consensus/pull/77

## What ❔

Add support for multiple leader selection modes: 
1. **Round robin**: based on validator's index, non-weighted. 
2. **Sticky**: constant leader. 
3. **Weighted**: pseudo-random, weighted. 

## Why ❔

To ease protocol upgrades.

---

### Notes
* Selection mode is considered as part of the genesis/network config.
* Weighted selection calculation can be optimized, but I'm not sure it's needed.

### TODOs
* Wait for https://github.com/matter-labs/era-consensus/pull/77 to be merged.
* Consider decouple `view_leader()` code and perhaps all of `Committee` struct from `/messages/consensus.rs` since it's not really related to messaging.
* Add external config support.
* Add tests.
* Add docs.
