### PR TITLE
Added support for persisting blocks in parallel

### DIFF
--- a/node/.config/nextest.toml
+++ b/node/.config/nextest.toml
@@ -20,6 +20,7 @@ final-status-level = "slow"
 
 # Profile for CI runs.
 [profile.ci]
+slow-timeout = { period = "60s", terminate-after = 2, grace-period = "0s" }
 # "retries" defines the number of times a test should be retried. If set to a
 # non-zero value, tests that succeed on a subsequent attempt will be marked as
 # non-flaky. Can be overridden through the `--retries` option.

--- a/node/actors/bft/src/replica/block.rs
+++ b/node/actors/bft/src/replica/block.rs
@@ -1,5 +1,4 @@
 use super::StateMachine;
-use tracing::instrument;
 use zksync_concurrency::ctx;
 use zksync_consensus_roles::validator;
 
@@ -7,7 +6,7 @@ impl StateMachine {
     /// Tries to build a finalized block from the given CommitQC. We simply search our
     /// block proposal cache for the matching block, and if we find it we build the block.
     /// If this method succeeds, it sends the finalized block to the executor.
-    #[instrument(level = "debug", skip(self), ret)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn save_block(
         &mut self,
         ctx: &ctx::Ctx,

--- a/node/actors/bft/src/replica/leader_prepare.rs
+++ b/node/actors/bft/src/replica/leader_prepare.rs
@@ -115,7 +115,7 @@ impl StateMachine {
         // (because it won't be able to persist and broadcast them once finalized).
         // TODO(gprusak): it should never happen, we should add safety checks to prevent
         // pruning blocks not known to be finalized.
-        if message.proposal.number < self.config.block_store.subscribe().borrow().first {
+        if message.proposal.number < self.config.block_store.queued().first {
             return Err(Error::ProposalAlreadyPruned);
         }
 

--- a/node/actors/bft/src/replica/tests.rs
+++ b/node/actors/bft/src/replica/tests.rs
@@ -177,8 +177,7 @@ async fn leader_prepare_pruned_block() {
             .replica
             .config
             .block_store
-            .subscribe()
-            .borrow()
+            .queued()
             .first
             .prev()
             .unwrap();

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -46,11 +46,11 @@ impl Test {
             s.spawn_bg(run_nodes(ctx, self.network, &nodes));
 
             // Run the nodes until all honest nodes store enough finalized blocks.
-            assert!(self.blocks_to_finalize>0);
+            assert!(self.blocks_to_finalize > 0);
             let first = setup.genesis.fork.first_block;
-            let last = first + (self.blocks_to_finalize as u64-1);
+            let last = first + (self.blocks_to_finalize as u64 - 1);
             for store in &honest {
-                store.wait_until_queued(ctx,last).await?;
+                store.wait_until_queued(ctx, last).await?;
             }
 
             // Check that the stored blocks are consistent.

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -129,8 +129,7 @@ async fn test_validator_syncing_from_fullnode() {
         // `store.state.first`.
         // Validator should fetch the past blocks from the full node before producing next blocks.
         let last_block = node_store
-            .subscribe()
-            .borrow()
+            .queued()
             .last
             .as_ref()
             .unwrap()

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -128,13 +128,7 @@ async fn test_validator_syncing_from_fullnode() {
         // Restart the validator with empty store (but preserved replica state) and non-trivial
         // `store.state.first`.
         // Validator should fetch the past blocks from the full node before producing next blocks.
-        let last_block = node_store
-            .queued()
-            .last
-            .as_ref()
-            .unwrap()
-            .header()
-            .number;
+        let last_block = node_store.queued().last.as_ref().unwrap().header().number;
         let (store, runner) =
             new_store_with_first(ctx, &setup.genesis, setup.genesis.fork.first_block + 2).await;
         s.spawn_bg(runner.run(ctx));

--- a/node/actors/network/src/gossip/runner.rs
+++ b/node/actors/network/src/gossip/runner.rs
@@ -128,7 +128,10 @@ impl Network {
                 loop {
                     let req = rpc::push_block_store_state::Req(state.clone());
                     push_block_store_state_client.call(ctx, &req, kB).await?;
-                    state = self.block_store.wait_until_queued(ctx,state.next()).await?;
+                    state = self
+                        .block_store
+                        .wait_until_queued(ctx, state.next())
+                        .await?;
                 }
             });
 

--- a/node/actors/network/src/gossip/runner.rs
+++ b/node/actors/network/src/gossip/runner.rs
@@ -79,7 +79,6 @@ impl rpc::Handler<rpc::get_block::Rpc> for &BlockStore {
 
 impl Network {
     /// Manages lifecycle of a single connection.
-    #[tracing::instrument(level = "info", name = "gossip", skip_all)]
     async fn run_stream(
         &self,
         ctx: &ctx::Ctx,
@@ -160,6 +159,7 @@ impl Network {
 
     /// Handles an inbound stream.
     /// Closes the stream if there is another inbound stream opened from the same peer.
+    #[tracing::instrument(level = "info", name = "gossip", skip_all)]
     pub(crate) async fn run_inbound_stream(
         &self,
         ctx: &ctx::Ctx,
@@ -178,6 +178,7 @@ impl Network {
     }
 
     /// Connects to a peer and handles the resulting stream.
+    #[tracing::instrument(level = "info", name = "gossip", skip_all)]
     pub(crate) async fn run_outbound_stream(
         &self,
         ctx: &ctx::Ctx,
@@ -200,6 +201,7 @@ impl Network {
             peer,
         )
         .await?;
+        tracing::info!("peer = {peer:?}");
         let conn = Arc::new(Connection {
             get_block: rpc::Client::<rpc::get_block::Rpc>::new(ctx, self.cfg.rpc.get_block_rate),
         });

--- a/node/actors/sync_blocks/src/peers/mod.rs
+++ b/node/actors/sync_blocks/src/peers/mod.rs
@@ -100,7 +100,7 @@ impl PeerStates {
     pub(crate) async fn run_block_fetcher(&self, ctx: &ctx::Ctx) -> ctx::Result<()> {
         let sem = sync::Semaphore::new(self.config.max_concurrent_blocks);
         scope::run!(ctx, |ctx, s| async {
-            let mut next = self.storage.subscribe().borrow().next();
+            let mut next = self.storage.queued().next();
             let mut highest_peer_block = self.highest_peer_block.subscribe();
             loop {
                 sync::wait_for(ctx, &mut highest_peer_block, |highest_peer_block| {

--- a/node/actors/sync_blocks/src/tests/end_to_end.rs
+++ b/node/actors/sync_blocks/src/tests/end_to_end.rs
@@ -192,7 +192,7 @@ impl GossipNetworkTest for BasicSynchronization {
         tracing::info!("Check initial node states");
         for node in &nodes {
             node.start();
-            let state = node.store.subscribe().borrow().clone();
+            let state = node.store.queued();
             assert_eq!(state.first, setup.genesis.fork.first_block);
             assert_eq!(state.last, None);
         }
@@ -372,7 +372,7 @@ async fn test_different_first_block() {
             // Find nodes interested in the next block.
             let interested_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.store.subscribe().borrow().first <= block.number())
+                .filter(|n| n.store.queued().first <= block.number())
                 .collect();
             // Store this block to one of them.
             if let Some(node) = interested_nodes.choose(rng) {

--- a/node/libs/concurrency/src/net/mod.rs
+++ b/node/libs/concurrency/src/net/mod.rs
@@ -1,6 +1,7 @@
 //! Context-aware network utilities.
 //! Built on top of `tokio::net`.
 use crate::ctx;
+use std::fmt;
 
 pub mod tcp;
 
@@ -11,8 +12,14 @@ mod tests;
 /// NOT VALIDATED, validation happens at `Host::resolve()` call.
 // TODO: for better type safety consider verifying host to be in the valid
 // format in constructor.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Host(pub String);
+
+impl fmt::Debug for Host {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
 
 impl From<std::net::SocketAddr> for Host {
     fn from(addr: std::net::SocketAddr) -> Self {

--- a/node/libs/storage/src/block_store/metrics.rs
+++ b/node/libs/storage/src/block_store/metrics.rs
@@ -15,7 +15,7 @@ pub(super) struct PersistentBlockStore {
     pub(super) block_latency: vise::Histogram<time::Duration>,
     /// Latency of a successful `store_next_block()` call.
     #[metrics(unit = vise::Unit::Seconds, buckets = vise::Buckets::LATENCIES)]
-    pub(super) store_next_block_latency: vise::Histogram<time::Duration>,
+    pub(super) queue_next_block_latency: vise::Histogram<time::Duration>,
 }
 
 #[vise::register]

--- a/node/libs/storage/src/block_store/mod.rs
+++ b/node/libs/storage/src/block_store/mod.rs
@@ -1,7 +1,7 @@
 //! Defines storage layer for finalized blocks.
 use anyhow::Context as _;
 use std::{collections::VecDeque, fmt, sync::Arc};
-use zksync_concurrency::{ctx, error::Wrap as _, sync};
+use zksync_concurrency::{ctx, scope, error::Wrap as _, sync};
 use zksync_consensus_roles::validator;
 
 mod metrics;
@@ -63,38 +63,71 @@ pub trait PersistentBlockStore: 'static + fmt::Debug + Send + Sync {
     /// Consensus code calls this method only once.
     async fn genesis(&self, ctx: &ctx::Ctx) -> ctx::Result<validator::Genesis>;
 
-    /// Range of blocks available in storage.
-    /// Consensus code calls this method only once and then tracks the
-    /// range of available blocks internally.
-    async fn state(&self, ctx: &ctx::Ctx) -> ctx::Result<BlockStoreState>;
+    /// Range of blocks persisted in storage.
+    fn persisted(&self) -> sync::watch::Receiver<BlockStoreState>;
 
     /// Gets a block by its number.
+    /// All the blocks from `state()` range are expected to be available.
+    /// Blocks that have been queued but haven't been persisted yet don't have to be available.
     /// Returns error if block is missing.
-    /// Caller is expected to know the state (by calling `state()`)
-    /// and only request the blocks contained in the state.
     async fn block(
         &self,
         ctx: &ctx::Ctx,
         number: validator::BlockNumber,
     ) -> ctx::Result<validator::FinalBlock>;
 
-    /// Persistently store a block.
-    /// Implementations are only required to accept a block directly after the current last block,
-    /// so that the stored blocks always constitute a continuous range.
-    /// Implementation should return only after the block is stored PERSISTENTLY -
-    /// consensus liveness property depends on this behavior.
-    async fn store_next_block(
+    /// Queue the block to be persisted in storage.
+    /// `queue_next_block()` may return BEFORE the block is actually persisted,
+    /// but if the call succeeded the block is expected to be persisted eventually.
+    /// Implementations are only required to accept a block directly after the previous queued
+    /// block, starting with `persisted().borrow().next()`.
+    async fn queue_next_block(
         &self,
         ctx: &ctx::Ctx,
-        block: &validator::FinalBlock,
+        block: validator::FinalBlock,
     ) -> ctx::Result<()>;
 }
 
 #[derive(Debug)]
 struct Inner {
-    queued_state: sync::watch::Sender<BlockStoreState>,
-    persisted_state: BlockStoreState,
-    queue: VecDeque<validator::FinalBlock>,
+    available: BlockStoreState,
+    persisted: BlockStoreState,
+    cache: VecDeque<validator::FinalBlock>,
+}
+
+impl Inner {
+    /// Minimal number of most recent blocks to keep in memory.
+    /// It allows to serve the recent blocks to peers fast, even
+    /// if persistent storage reads are slow (like in RocksDB).
+    /// `BlockStore` may keep in memory more blocks in case
+    /// blocks are queued faster than they are persisted.
+    const CACHE_CAPACITY : usize = 100;
+
+    /// Tries to push the next block to cache.
+    /// Noop if provided block is not the expected one.
+    /// Returns true iff cache has been modified.
+    fn try_push(&mut self, block: validator::FinalBlock) -> bool {
+        if self.available.next()!=block.number() {
+            return false;
+        }
+        self.available.last = Some(block.justification.clone());
+        self.cache.push_back(block);
+        self.truncate_cache();
+        true
+    }
+
+    fn truncate_cache(&mut self) {
+        while self.cache.len()>Self::CACHE_CAPACITY && self.persisted.contains(self.cache[0].number()) {
+            self.cache.pop_front();
+        }
+    }
+
+    fn block(&self, n: validator::BlockNumber) -> Option<validator::FinalBlock> {
+        // Subtraction is safe, because blocks in cache are
+        // stored in increasing order of block number.
+        let first = self.cache.front()?;
+        self.cache.get((n.0-first.number().0) as usize).cloned()
+    }
 }
 
 /// A wrapper around a PersistentBlockStore which adds caching blocks in-memory
@@ -118,34 +151,37 @@ impl BlockStoreRunner {
         let store_ref = Arc::downgrade(&self.0);
         let _ = COLLECTOR.before_scrape(move || Some(store_ref.upgrade()?.scrape_metrics()));
 
-        let res = async {
+        let res = scope::run!(ctx, |ctx,s| async {
+            let persisted = self.0.persistent.persisted();
+            let mut queue_next = persisted.borrow().next();
+            // Task truncating cache whenever a block gets persisted.
+            s.spawn::<()>(async {
+                let mut persisted = persisted;
+                loop {
+                    let persisted = sync::changed(ctx, &mut persisted).await?.clone();
+                    self.0.inner.send_modify(|inner| {
+                        inner.persisted = persisted;
+                        inner.truncate_cache();
+                    });
+                }
+            });
+            // Task queueing blocks to be persisted.
             let inner = &mut self.0.inner.subscribe();
             loop {
-                let block = sync::wait_for(ctx, inner, |inner| !inner.queue.is_empty())
+                let block = sync::wait_for(ctx, inner, |inner| !inner.available.contains(queue_next))
                     .await?
-                    .queue[0]
-                    .clone();
+                    .block(queue_next)
+                    .unwrap();
+                queue_next = queue_next.next();
 
                 // TODO: monitor errors as well.
                 let t = metrics::PERSISTENT_BLOCK_STORE
-                    .store_next_block_latency
+                    .queue_next_block_latency
                     .start();
-                self.0.persistent.store_next_block(ctx, &block).await?;
+                self.0.persistent.queue_next_block(ctx, block).await?;
                 t.observe();
-                tracing::info!(
-                    "stored block #{}: {:#?}",
-                    block.header().number,
-                    block.header().payload
-                );
-
-                self.0.inner.send_modify(|inner| {
-                    debug_assert_eq!(inner.persisted_state.next(), block.number());
-                    inner.persisted_state.last = Some(block.justification.clone());
-                    inner.queue.pop_front();
-                });
             }
-        }
-        .await;
+        }).await;
         match res {
             Ok(()) | Err(ctx::Error::Canceled(_)) => Ok(()),
             Err(ctx::Error::Internal(err)) => Err(err),
@@ -165,15 +201,13 @@ impl BlockStore {
         let t = metrics::PERSISTENT_BLOCK_STORE.genesis_latency.start();
         let genesis = persistent.genesis(ctx).await.wrap("persistent.genesis()")?;
         t.observe();
-        let t = metrics::PERSISTENT_BLOCK_STORE.state_latency.start();
-        let state = persistent.state(ctx).await.wrap("persistent.state()")?;
-        t.observe();
-        state.verify(&genesis).context("state.verify()")?;
+        let persisted = persistent.persisted().borrow().clone();
+        persisted.verify(&genesis).context("state.verify()")?;
         let this = Arc::new(Self {
             inner: sync::watch::channel(Inner {
-                queued_state: sync::watch::channel(state.clone()).0,
-                persisted_state: state,
-                queue: VecDeque::new(),
+                available: persisted.clone(),
+                persisted: persisted,
+                cache: VecDeque::new(),
             })
             .0,
             genesis,
@@ -187,6 +221,11 @@ impl BlockStore {
         &self.genesis
     }
 
+    /// Available blocks (in memory & persisted).
+    pub fn available(&self) -> BlockStoreState {
+        self.inner.borrow().available.clone()
+    }
+
     /// Fetches a block (from queue or persistent storage).
     pub async fn block(
         &self,
@@ -195,14 +234,11 @@ impl BlockStore {
     ) -> ctx::Result<Option<validator::FinalBlock>> {
         {
             let inner = self.inner.borrow();
-            if !inner.queued_state.borrow().contains(number) {
+            if !inner.available.contains(number) {
                 return Ok(None);
             }
-            if !inner.persisted_state.contains(number) {
-                // Subtraction is safe, because we know that the block
-                // is in inner.queue at this point.
-                let idx = number.0 - inner.persisted_state.next().0;
-                return Ok(inner.queue.get(idx as usize).cloned());
+            if let Some(block) = inner.block(number) {
+                return Ok(Some(block));
             }
         }
         let t = metrics::PERSISTENT_BLOCK_STORE.block_latency.start();
@@ -215,7 +251,7 @@ impl BlockStore {
         Ok(Some(block))
     }
 
-    /// Insert block to a queue to be persisted eventually.
+    /// Append block to a queue to be persisted eventually.
     /// Since persisting a block may take a significant amount of time,
     /// BlockStore contains a queue of blocks waiting to be persisted.
     /// `queue_block()` adds a block to the queue as soon as all intermediate
@@ -226,74 +262,39 @@ impl BlockStore {
         ctx: &ctx::Ctx,
         block: validator::FinalBlock,
     ) -> ctx::Result<()> {
-        let number = block.number();
-        {
-            let sub = &mut self.subscribe();
-            let queued_state =
-                sync::wait_for(ctx, sub, |queued_state| queued_state.next() >= number).await?;
-            if queued_state.next() > number {
-                return Ok(());
-            }
-            block.verify(&self.genesis).context("block.verify()")?;
-        }
-        self.inner.send_if_modified(|inner| {
-            let modified = inner.queued_state.send_if_modified(|queued_state| {
-                // It may happen that the same block is queued_state by 2 calls.
-                if queued_state.next() != number {
-                    return false;
-                }
-                queued_state.last = Some(block.justification.clone());
-                true
-            });
-            if !modified {
-                return false;
-            }
-            inner.queue.push_back(block);
-            true
-        });
+        block.verify(&self.genesis).context("block.verify()")?;
+        sync::wait_for(ctx, &mut self.inner.subscribe(), |inner| inner.available.next() >= block.number()).await?;
+        self.inner.send_if_modified(|inner| inner.try_push(block));
         Ok(())
     }
 
-    /// Waits until the given block is queued to be stored.
-    /// If `number < state.first` then it immetiately returns `Ok(())`.
+    /// Waits until the given block is queued (in memory, or persisted).
+    /// Note that it doesn't mean that the block is actually available, as old blocks might get pruned.
     pub async fn wait_until_queued(
         &self,
         ctx: &ctx::Ctx,
         number: validator::BlockNumber,
     ) -> ctx::OrCanceled<()> {
-        sync::wait_for(ctx, &mut self.subscribe(), |queued_state| {
-            number < queued_state.next()
-        })
-        .await?;
+        sync::wait_for(ctx, &mut self.inner.subscribe(), |inner| number < inner.available.next()).await?;
         Ok(())
     }
 
     /// Waits until the given block is stored persistently.
-    /// If `number < state.first` then it immetiately returns `Ok(())`.
+    /// Note that it doesn't mean that the block is actually available, as old blocks might get pruned.
     pub async fn wait_until_persisted(
         &self,
         ctx: &ctx::Ctx,
         number: validator::BlockNumber,
     ) -> ctx::OrCanceled<()> {
-        sync::wait_for(ctx, &mut self.inner.subscribe(), |inner| {
-            number < inner.persisted_state.next()
-        })
-        .await?;
+        sync::wait_for(ctx, &mut self.persistent.persisted(), |persisted| number < persisted.next()).await?;
         Ok(())
-    }
-
-    /// Subscribes to the `BlockStoreState` changes.
-    /// Note that this state includes both queue AND stored blocks.
-    pub fn subscribe(&self) -> sync::watch::Receiver<BlockStoreState> {
-        self.inner.borrow().queued_state.subscribe()
     }
 
     fn scrape_metrics(&self) -> metrics::BlockStore {
         let m = metrics::BlockStore::default();
         let inner = self.inner.borrow();
-        m.next_queued_block
-            .set(inner.queued_state.borrow().next().0);
-        m.next_persisted_block.set(inner.persisted_state.next().0);
+        m.next_queued_block.set(inner.available.next().0);
+        m.next_persisted_block.set(inner.persisted.next().0);
         m
     }
 }

--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -5,13 +5,13 @@ use std::{
     collections::VecDeque,
     sync::{Arc, Mutex},
 };
-use zksync_concurrency::ctx;
+use zksync_concurrency::{sync,ctx};
 use zksync_consensus_roles::validator;
 
 #[derive(Debug)]
 struct BlockStoreInner {
-    first: validator::BlockNumber,
     genesis: validator::Genesis,
+    persisted: sync::watch::Sender<BlockStoreState>,
     blocks: Mutex<VecDeque<validator::FinalBlock>>,
 }
 
@@ -28,8 +28,8 @@ impl BlockStore {
     pub fn new(genesis: validator::Genesis, first: validator::BlockNumber) -> Self {
         assert!(genesis.fork.first_block <= first);
         Self(Arc::new(BlockStoreInner {
-            first,
             genesis,
+            persisted: sync::watch::channel(BlockStoreState { first, last: None }).0,
             blocks: Mutex::default(),
         }))
     }
@@ -41,17 +41,8 @@ impl PersistentBlockStore for BlockStore {
         Ok(self.0.genesis.clone())
     }
 
-    async fn state(&self, _ctx: &ctx::Ctx) -> ctx::Result<BlockStoreState> {
-        Ok(BlockStoreState {
-            first: self.0.first,
-            last: self
-                .0
-                .blocks
-                .lock()
-                .unwrap()
-                .back()
-                .map(|b| b.justification.clone()),
-        })
+    fn persisted(&self) -> sync::watch::Receiver<BlockStoreState> {
+        self.0.persisted.subscribe()
     }
 
     async fn block(
@@ -68,21 +59,18 @@ impl PersistentBlockStore for BlockStore {
         Ok(blocks.get(idx as usize).context("not found")?.clone())
     }
 
-    async fn store_next_block(
+    async fn queue_next_block(
         &self,
         _ctx: &ctx::Ctx,
-        block: &validator::FinalBlock,
+        block: validator::FinalBlock,
     ) -> ctx::Result<()> {
         let mut blocks = self.0.blocks.lock().unwrap();
-        let got = block.header().number;
-        let want = match blocks.back() {
-            Some(last) => last.header().number.next(),
-            None => self.0.first,
-        };
-        if got != want {
-            return Err(anyhow::anyhow!("got block {got:?}, while expected {want:?}").into());
+        let want = self.0.persisted.borrow().next();
+        if block.number() != want {
+            return Err(anyhow::anyhow!("got block {:?}, want {want:?}",block.number()).into());
         }
-        blocks.push_back(block.clone());
+        self.0.persisted.send_modify(|p|p.last = Some(block.justification.clone()));
+        blocks.push_back(block);
         Ok(())
     }
 }

--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -5,7 +5,7 @@ use std::{
     collections::VecDeque,
     sync::{Arc, Mutex},
 };
-use zksync_concurrency::{sync,ctx};
+use zksync_concurrency::{ctx, sync};
 use zksync_consensus_roles::validator;
 
 #[derive(Debug)]
@@ -67,9 +67,11 @@ impl PersistentBlockStore for BlockStore {
         let mut blocks = self.0.blocks.lock().unwrap();
         let want = self.0.persisted.borrow().next();
         if block.number() != want {
-            return Err(anyhow::anyhow!("got block {:?}, want {want:?}",block.number()).into());
+            return Err(anyhow::anyhow!("got block {:?}, want {want:?}", block.number()).into());
         }
-        self.0.persisted.send_modify(|p|p.last = Some(block.justification.clone()));
+        self.0
+            .persisted
+            .send_modify(|p| p.last = Some(block.justification.clone()));
         blocks.push_back(block);
         Ok(())
     }

--- a/node/libs/storage/src/testonly/mod.rs
+++ b/node/libs/storage/src/testonly/mod.rs
@@ -77,7 +77,7 @@ pub async fn dump(ctx: &ctx::Ctx, store: &dyn PersistentBlockStore) -> Vec<valid
 
 /// Verifies storage content.
 pub async fn verify(ctx: &ctx::Ctx, store: &BlockStore) -> anyhow::Result<()> {
-    let range = store.available();
+    let range = store.queued();
     for n in (range.first.0..range.next().0).map(validator::BlockNumber) {
         async {
             store

--- a/node/libs/storage/src/testonly/mod.rs
+++ b/node/libs/storage/src/testonly/mod.rs
@@ -55,7 +55,7 @@ pub async fn new_store_with_first(
 /// Dumps all the blocks stored in `store`.
 pub async fn dump(ctx: &ctx::Ctx, store: &dyn PersistentBlockStore) -> Vec<validator::FinalBlock> {
     let genesis = store.genesis(ctx).await.unwrap();
-    let state = store.state(ctx).await.unwrap();
+    let state = store.persisted().borrow().clone();
     assert!(genesis.fork.first_block <= state.first);
     let mut blocks = vec![];
     let after = state
@@ -77,7 +77,7 @@ pub async fn dump(ctx: &ctx::Ctx, store: &dyn PersistentBlockStore) -> Vec<valid
 
 /// Verifies storage content.
 pub async fn verify(ctx: &ctx::Ctx, store: &BlockStore) -> anyhow::Result<()> {
-    let range = store.subscribe().borrow().clone();
+    let range = store.available();
     for n in (range.first.0..range.next().0).map(validator::BlockNumber) {
         async {
             store

--- a/node/libs/storage/src/tests.rs
+++ b/node/libs/storage/src/tests.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::{testonly::new_store_with_first, ReplicaState};
-use zksync_concurrency::{ctx, scope, testonly::abort_on_panic};
+use zksync_concurrency::{ctx, sync, scope, testonly::abort_on_panic};
 use zksync_consensus_roles::validator::testonly::Setup;
 
 #[tokio::test]
 async fn test_inmemory_block_store() {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
     let mut setup = Setup::new(rng, 3);
@@ -16,7 +17,8 @@ async fn test_inmemory_block_store() {
     );
     let mut want = vec![];
     for block in &setup.blocks {
-        store.store_next_block(ctx, block).await.unwrap();
+        store.queue_next_block(ctx, block.clone()).await.unwrap();
+        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(block.number())).await.unwrap();
         want.push(block.clone());
         assert_eq!(want, testonly::dump(ctx, store).await);
     }
@@ -41,7 +43,6 @@ async fn test_state_updates() {
     let (store, runner) = new_store_with_first(ctx, &setup.genesis, first_block.number()).await;
     scope::run!(ctx, |ctx, s| async {
         s.spawn_bg(runner.run(ctx));
-        let sub = &mut store.subscribe();
         let want = BlockStoreState {
             first: first_block.number(),
             last: None,
@@ -55,7 +56,7 @@ async fn test_state_updates() {
         ] {
             store.wait_until_queued(ctx, n).await.unwrap();
             store.wait_until_persisted(ctx, n).await.unwrap();
-            assert_eq!(want, *sub.borrow());
+            assert_eq!(want, store.available());
         }
 
         for block in &setup.blocks {
@@ -67,7 +68,7 @@ async fn test_state_updates() {
                     .wait_until_persisted(ctx, block.number())
                     .await
                     .unwrap();
-                assert_eq!(want, *sub.borrow());
+                assert_eq!(want, store.available());
             } else {
                 // Otherwise the state should be updated as soon as block is queued.
                 assert_eq!(
@@ -75,7 +76,7 @@ async fn test_state_updates() {
                         first: first_block.number(),
                         last: Some(block.justification.clone()),
                     },
-                    *sub.borrow()
+                    store.available()
                 );
             }
         }

--- a/node/libs/storage/src/tests.rs
+++ b/node/libs/storage/src/tests.rs
@@ -56,7 +56,7 @@ async fn test_state_updates() {
         ] {
             store.wait_until_queued(ctx, n).await.unwrap();
             store.wait_until_persisted(ctx, n).await.unwrap();
-            assert_eq!(want, store.available());
+            assert_eq!(want, store.queued());
         }
 
         for block in &setup.blocks {
@@ -68,7 +68,7 @@ async fn test_state_updates() {
                     .wait_until_persisted(ctx, block.number())
                     .await
                     .unwrap();
-                assert_eq!(want, store.available());
+                assert_eq!(want, store.queued());
             } else {
                 // Otherwise the state should be updated as soon as block is queued.
                 assert_eq!(
@@ -76,7 +76,7 @@ async fn test_state_updates() {
                         first: first_block.number(),
                         last: Some(block.justification.clone()),
                     },
-                    store.available()
+                    store.queued()
                 );
             }
         }

--- a/node/libs/storage/src/tests.rs
+++ b/node/libs/storage/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{testonly::new_store_with_first, ReplicaState};
-use zksync_concurrency::{ctx, sync, scope, testonly::abort_on_panic};
+use zksync_concurrency::{ctx, scope, sync, testonly::abort_on_panic};
 use zksync_consensus_roles::validator::testonly::Setup;
 
 #[tokio::test]
@@ -18,7 +18,9 @@ async fn test_inmemory_block_store() {
     let mut want = vec![];
     for block in &setup.blocks {
         store.queue_next_block(ctx, block.clone()).await.unwrap();
-        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(block.number())).await.unwrap();
+        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(block.number()))
+            .await
+            .unwrap();
         want.push(block.clone());
         assert_eq!(want, testonly::dump(ctx, store).await);
     }

--- a/node/tools/src/rpc/methods/last_committed_block.rs
+++ b/node/tools/src/rpc/methods/last_committed_block.rs
@@ -9,8 +9,7 @@ use zksync_consensus_storage::BlockStore;
 
 /// Last view response for /last_view endpoint.
 pub fn callback(node_storage: Arc<BlockStore>) -> RpcResult<serde_json::Value> {
-    let sub = &mut node_storage.subscribe();
-    let state = sub.borrow().clone();
+    let state = node_storage.queued();
     let last_committed_block_header = state
         .last
         .context("Failed to get last state")

--- a/node/tools/src/rpc/methods/last_view.rs
+++ b/node/tools/src/rpc/methods/last_view.rs
@@ -9,8 +9,7 @@ use zksync_consensus_storage::BlockStore;
 
 /// Last view response for /last_view endpoint.
 pub fn callback(node_storage: Arc<BlockStore>) -> RpcResult<serde_json::Value> {
-    let sub = &mut node_storage.subscribe();
-    let state = sub.borrow().clone();
+    let state = node_storage.queued();
     let last_view = state
         .last
         .context("Failed to get last state")
@@ -18,6 +17,8 @@ pub fn callback(node_storage: Arc<BlockStore>) -> RpcResult<serde_json::Value> {
         .view()
         .number
         .0;
+    // TODO(gprusak): this is the view of the last finalized block, not the current view of the
+    // replica. Fix this.
     Ok(serde_json::json!({
         "last_view": last_view
     }))

--- a/node/tools/src/store.rs
+++ b/node/tools/src/store.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
     sync::{Arc, RwLock},
 };
-use zksync_concurrency::{ctx, error::Wrap as _, scope};
+use zksync_concurrency::{ctx, error::Wrap as _, scope, sync};
 use zksync_consensus_roles::validator;
 use zksync_consensus_storage::{BlockStoreState, PersistentBlockStore, ReplicaState, ReplicaStore};
 
@@ -49,6 +49,7 @@ impl DatabaseKey {
 
 struct Inner {
     genesis: validator::Genesis,
+    persisted: sync::watch::Sender<BlockStoreState>,
     db: RwLock<rocksdb::DB>,
 }
 
@@ -67,19 +68,23 @@ impl RocksDB {
         let mut options = rocksdb::Options::default();
         options.create_missing_column_families(true);
         options.create_if_missing(true);
+        let db = scope::wait_blocking(|| {
+            rocksdb::DB::open(&options, path).context("Failed opening RocksDB")
+        })
+        .await?;
+
         Ok(Self(Arc::new(Inner {
+            persisted: sync::watch::channel(BlockStoreState {
+                // `RocksDB` is assumed to store all blocks starting from genesis.
+                first: genesis.fork.first_block,
+                last: scope::wait_blocking(|| Self::last_blocking(&db)).await?,
+            }).0,
             genesis,
-            db: RwLock::new(
-                scope::wait_blocking(|| {
-                    rocksdb::DB::open(&options, path).context("Failed opening RocksDB")
-                })
-                .await?,
-            ),
+            db: RwLock::new(db),           
         })))
     }
 
-    fn last_blocking(&self) -> anyhow::Result<Option<validator::CommitQC>> {
-        let db = self.0.db.read().unwrap();
+    fn last_blocking(db: &rocksdb::DB) -> anyhow::Result<Option<validator::CommitQC>> {
         let mut options = ReadOptions::default();
         options.set_iterate_range(DatabaseKey::BLOCKS_START_KEY..);
         let Some(res) = db
@@ -107,12 +112,8 @@ impl PersistentBlockStore for RocksDB {
         Ok(self.0.genesis.clone())
     }
 
-    async fn state(&self, _ctx: &ctx::Ctx) -> ctx::Result<BlockStoreState> {
-        Ok(BlockStoreState {
-            // `RocksDB` is assumed to store all blocks starting from genesis.
-            first: self.0.genesis.fork.first_block,
-            last: scope::wait_blocking(|| self.last_blocking()).await?,
-        })
+    fn persisted(&self) -> sync::watch::Receiver<BlockStoreState> {
+        self.0.persisted.subscribe()
     }
 
     async fn block(
@@ -133,26 +134,30 @@ impl PersistentBlockStore for RocksDB {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn store_next_block(
+    async fn queue_next_block(
         &self,
         _ctx: &ctx::Ctx,
-        block: &validator::FinalBlock,
+        block: validator::FinalBlock,
     ) -> ctx::Result<()> {
         scope::wait_blocking(|| {
             let db = self.0.db.write().unwrap();
+            let want = self.0.persisted.borrow().next();
+            anyhow::ensure!(block.number()==want, "got {:?} want {want:?}",block.number());
             let block_number = block.header().number;
             let mut write_batch = rocksdb::WriteBatch::default();
             write_batch.put(
                 DatabaseKey::Block(block_number).encode_key(),
-                zksync_protobuf::encode(block),
+                zksync_protobuf::encode(&block),
             );
             // Commit the transaction.
             db.write(write_batch)
                 .context("Failed writing block to database")?;
+            self.0.persisted.send_modify(|p|p.last = Some(block.justification.clone()));
             Ok(())
         })
         .await
-        .wrap(block.header().number)
+        .context(block.header().number)?;
+        Ok(())
     }
 }
 

--- a/node/tools/src/store.rs
+++ b/node/tools/src/store.rs
@@ -78,9 +78,10 @@ impl RocksDB {
                 // `RocksDB` is assumed to store all blocks starting from genesis.
                 first: genesis.fork.first_block,
                 last: scope::wait_blocking(|| Self::last_blocking(&db)).await?,
-            }).0,
+            })
+            .0,
             genesis,
-            db: RwLock::new(db),           
+            db: RwLock::new(db),
         })))
     }
 
@@ -142,7 +143,11 @@ impl PersistentBlockStore for RocksDB {
         scope::wait_blocking(|| {
             let db = self.0.db.write().unwrap();
             let want = self.0.persisted.borrow().next();
-            anyhow::ensure!(block.number()==want, "got {:?} want {want:?}",block.number());
+            anyhow::ensure!(
+                block.number() == want,
+                "got {:?} want {want:?}",
+                block.number()
+            );
             let block_number = block.header().number;
             let mut write_batch = rocksdb::WriteBatch::default();
             write_batch.put(
@@ -152,7 +157,9 @@ impl PersistentBlockStore for RocksDB {
             // Commit the transaction.
             db.write(write_batch)
                 .context("Failed writing block to database")?;
-            self.0.persisted.send_modify(|p|p.last = Some(block.justification.clone()));
+            self.0
+                .persisted
+                .send_modify(|p| p.last = Some(block.justification.clone()));
             Ok(())
         })
         .await

--- a/node/tools/src/tests.rs
+++ b/node/tools/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{store, AppConfig};
 use rand::{distributions::Distribution, Rng};
 use tempfile::TempDir;
-use zksync_concurrency::{ctx,sync};
+use zksync_concurrency::{ctx, sync};
 use zksync_consensus_roles::validator::testonly::Setup;
 use zksync_consensus_storage::{testonly, PersistentBlockStore};
 use zksync_consensus_utils::EncodeDist;
@@ -50,7 +50,9 @@ async fn test_reopen_rocksdb() {
             .await
             .unwrap();
         store.queue_next_block(ctx, b.clone()).await.unwrap();
-        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(b.number())).await.unwrap();
+        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(b.number()))
+            .await
+            .unwrap();
         want.push(b.clone());
         assert_eq!(want, testonly::dump(ctx, &store).await);
     }

--- a/node/tools/src/tests.rs
+++ b/node/tools/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{store, AppConfig};
 use rand::{distributions::Distribution, Rng};
 use tempfile::TempDir;
-use zksync_concurrency::ctx;
+use zksync_concurrency::{ctx,sync};
 use zksync_consensus_roles::validator::testonly::Setup;
 use zksync_consensus_storage::{testonly, PersistentBlockStore};
 use zksync_consensus_utils::EncodeDist;
@@ -49,7 +49,8 @@ async fn test_reopen_rocksdb() {
         let store = store::RocksDB::open(setup.genesis.clone(), dir.path())
             .await
             .unwrap();
-        store.store_next_block(ctx, b).await.unwrap();
+        store.queue_next_block(ctx, b.clone()).await.unwrap();
+        sync::wait_for(ctx, &mut store.persisted(), |p| p.contains(b.number())).await.unwrap();
         want.push(b.clone());
         assert_eq!(want, testonly::dump(ctx, &store).await);
     }


### PR DESCRIPTION
Statekeeper is storing blocks to postgres in parallel to processing next blocks. Our simplified API so far required persisting one block to finish before processing the next block. This effectively disabled the parallelization in statekeeper and therefore the EN with consensus enabled was significantly slower than EN without consensus. This PR updates the api to allow persisting multiple blocks in parallel. Long term this change most likely won't be that useful, because statekeeper of a validator node will have to work synchronously with consensus (but that requires improving statekeeper anyway).

I've also implemented caching inmemory the most recent blocks (even if they got persisted) to address the inefficiency found during the loadtest. 