### PR TITLE
Adjusted testonly utils

### DIFF
--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -18,15 +18,15 @@ use zksync_consensus_utils::enum_util::Variant;
 
 /// Test setup.
 #[derive(Debug, Clone)]
-pub struct Setup(SetupInner);
+pub struct Setup(SetupRaw);
 
-impl Setup {
-    /// New `Setup`.
+impl SetupRaw {
+    /// New `SetupRaw`.
     pub fn new(rng: &mut impl Rng, validators: usize) -> Self {
         Self::new_with_weights(rng, vec![1; validators])
     }
 
-    /// New `Setup`.
+    /// New `SetupRaw`.
     pub fn new_with_weights(rng: &mut impl Rng, weights: Vec<u64>) -> Self {
         let keys: Vec<SecretKey> = (0..weights.len()).map(|_| rng.gen()).collect();
         let genesis = GenesisRaw {
@@ -42,11 +42,23 @@ impl Setup {
             leader_selection: LeaderSelectionMode::RoundRobin,
         }
         .with_hash();
-        Self(SetupInner {
+        Self {
             keys,
             genesis,
             blocks: vec![],
-        })
+        }
+    }
+}
+
+impl Setup {
+    /// New `Setup`.
+    pub fn new(rng: &mut impl Rng, validators: usize) -> Self {
+        SetupRaw::new(rng, validators).into()
+    }
+
+    /// New `Setup`.
+    pub fn new_with_weights(rng: &mut impl Rng, weights: Vec<u64>) -> Self {
+        SetupRaw::new_with_weights(rng, weights).into()
     }
 
     /// Next block to finalize.
@@ -108,7 +120,7 @@ impl Setup {
 
 /// Setup.
 #[derive(Debug, Clone)]
-pub struct SetupInner {
+pub struct SetupRaw {
     /// Validators' secret keys.
     pub keys: Vec<SecretKey>,
     /// Past blocks.
@@ -118,10 +130,14 @@ pub struct SetupInner {
 }
 
 impl std::ops::Deref for Setup {
-    type Target = SetupInner;
+    type Target = SetupRaw;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
+}
+
+impl From<SetupRaw> for Setup {
+    fn from(x: SetupRaw) -> Self { Self(x) }
 }
 
 impl AggregateSignature {

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -24,16 +24,15 @@ pub struct SetupSpec {
     /// Fork number.
     pub fork_number: ForkNumber,
     /// First block.
-    pub first_block: BlockNumber,   
+    pub first_block: BlockNumber,
 
     /// Protocol version.
     pub protocol_version: ProtocolVersion,
     /// Validator secret keys and weights.
-    pub weights: Vec<(SecretKey,u64)>, 
+    pub weights: Vec<(SecretKey, u64)>,
     /// Leader selection.
     pub leader_selection: LeaderSelectionMode,
 }
-
 
 /// Test setup.
 #[derive(Debug, Clone)]
@@ -47,7 +46,7 @@ impl SetupSpec {
     /// New `SetupSpec`.
     pub fn new_with_weights(rng: &mut impl Rng, weights: Vec<u64>) -> Self {
         Self {
-            weights: weights.into_iter().map(|w| (rng.gen(),w)).collect(),
+            weights: weights.into_iter().map(|w| (rng.gen(), w)).collect(),
             chain_id: ChainId(1337),
             fork_number: ForkNumber(rng.gen_range(0..100)),
             first_block: BlockNumber(rng.gen_range(0..100)),
@@ -134,13 +133,15 @@ impl From<SetupSpec> for Setup {
                 first_block: spec.first_block,
 
                 protocol_version: spec.protocol_version,
-                committee: Committee::new(spec.weights.iter().map(|(k,w)|WeightedValidator {
+                committee: Committee::new(spec.weights.iter().map(|(k, w)| WeightedValidator {
                     key: k.public(),
                     weight: *w,
-                })).unwrap(),
+                }))
+                .unwrap(),
                 leader_selection: spec.leader_selection,
-            }.with_hash(),
-            keys: spec.weights.into_iter().map(|(k,_)|k).collect(),
+            }
+            .with_hash(),
+            keys: spec.weights.into_iter().map(|(k, _)| k).collect(),
             blocks: vec![],
         })
     }


### PR DESCRIPTION
Added more flexibility in constructing `validator::testonly::Setup` for zksync-era tests.