### PR TITLE
Return Result<(), Error> on QC add 

### DIFF
--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -105,6 +105,7 @@ impl StateMachine {
         // ----------- All checks finished. Now we process the message. --------------
 
         // Add the message to the QC.
+        // Should always succeed as all checks have been already performed
         commit_qc
             .add(&signed_message, self.config.genesis())
             .expect("Could not add message to CommitQC");

--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -105,7 +105,9 @@ impl StateMachine {
         // ----------- All checks finished. Now we process the message. --------------
 
         // Add the message to the QC.
-        commit_qc.add(&signed_message, self.config.genesis());
+        commit_qc
+            .add(&signed_message, self.config.genesis())
+            .expect("Could not add message to CommitQC");
 
         // Now we check if we have enough weight to continue.
         let weight = self.config.genesis().committee.weight(&commit_qc.signers);

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -115,7 +115,9 @@ impl StateMachine {
             .prepare_qcs
             .entry(message.view.number)
             .or_insert_with(|| validator::PrepareQC::new(message.view.clone()));
-        prepare_qc.add(&signed_message, self.config.genesis());
+        prepare_qc
+            .add(&signed_message, self.config.genesis())
+            .expect("Could not add message to PrepareQC");
 
         // We store the message in our cache.
         self.prepare_message_cache

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -115,6 +115,8 @@ impl StateMachine {
             .prepare_qcs
             .entry(message.view.number)
             .or_insert_with(|| validator::PrepareQC::new(message.view.clone()));
+
+        // Should always succeed as all checks have been already performed
         prepare_qc
             .add(&signed_message, self.config.genesis())
             .expect("Could not add message to PrepareQC");

--- a/node/actors/bft/src/replica/tests.rs
+++ b/node/actors/bft/src/replica/tests.rs
@@ -214,7 +214,9 @@ async fn leader_prepare_invalid_payload() {
             },
             util.genesis(),
         );
-        justification.add(&util.sign(justification.message.clone()), util.genesis());
+        justification
+            .add(&util.sign(justification.message.clone()), util.genesis())
+            .unwrap();
         let block = validator::FinalBlock {
             payload: leader_prepare.proposal_payload.clone().unwrap(),
             justification,
@@ -417,7 +419,7 @@ async fn leader_prepare_reproposal_without_quorum() {
             replica_prepare.high_vote.as_mut().unwrap().proposal.payload = rng.gen();
             leader_prepare
                 .justification
-                .add(&key.sign_msg(replica_prepare.clone()), util.genesis());
+                .add(&key.sign_msg(replica_prepare.clone()), util.genesis())?;
         }
         let res = util
             .process_leader_prepare(ctx, util.sign(leader_prepare))

--- a/node/actors/bft/src/testonly/ut_harness.rs
+++ b/node/actors/bft/src/testonly/ut_harness.rs
@@ -304,7 +304,8 @@ impl UTHarness {
         mutate_fn(&mut msg);
         let mut qc = CommitQC::new(msg, self.genesis());
         for key in &self.keys {
-            qc.add(&key.sign_msg(qc.message.clone()), self.genesis());
+            qc.add(&key.sign_msg(qc.message.clone()), self.genesis())
+                .unwrap();
         }
         qc
     }
@@ -317,7 +318,7 @@ impl UTHarness {
         mutate_fn(&mut msg);
         let mut qc = PrepareQC::new(msg.view.clone());
         for key in &self.keys {
-            qc.add(&key.sign_msg(msg.clone()), self.genesis());
+            qc.add(&key.sign_msg(msg.clone()), self.genesis()).unwrap();
         }
         qc
     }

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -58,7 +58,7 @@ pub enum CommitQCVerifyError {
 #[derive(thiserror::Error, Debug)]
 pub enum CommitQCAddError {
     /// Inconsistent views.
-    #[error("inconsistent views of signed messages")]
+    #[error("Trying to add a message from a diferent view")]
     InconsistentViews,
     /// Validator not present in the committee.
     #[error("Validator not in committee: {signer:?}")]

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -67,11 +67,8 @@ pub enum CommitQCAddError {
         signer: Box<validator::PublicKey>,
     },
     /// Message already present in CommitQC.
-    #[error("Message already signed for CommitQC: {existing_message:?}")]
-    Exists {
-        /// Existing message from the same replica.
-        existing_message: Box<ReplicaCommit>,
-    },
+    #[error("Message already signed for CommitQC")]
+    Exists,
 }
 
 impl CommitQC {
@@ -111,9 +108,7 @@ impl CommitQC {
             });
         };
         if self.signers.0[i] {
-            return Err(Error::Exists {
-                existing_message: Box::new(msg.msg.clone()),
-            });
+            return Err(Error::Exists);
         };
         self.signers.0.set(i, true);
         self.signature.add(&msg.sig);

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -60,9 +60,9 @@ pub enum CommitQCAddError {
     /// Inconsistent views.
     #[error("Trying to add a message from a diferent view")]
     InconsistentViews,
-    /// Validator not present in the committee.
-    #[error("Validator not in committee: {signer:?}")]
-    ValidatorNotInCommittee {
+    /// Signer not present in the committee.
+    #[error("Signer not in committee: {signer:?}")]
+    SignerNotInCommittee {
         /// Signer of the message.
         signer: Box<validator::PublicKey>,
     },
@@ -106,7 +106,7 @@ impl CommitQC {
             return Err(Error::InconsistentViews);
         };
         let Some(i) = genesis.committee.index(&msg.key) else {
-            return Err(Error::ValidatorNotInCommittee {
+            return Err(Error::SignerNotInCommittee {
                 signer: Box::new(msg.key.clone()),
             });
         };

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -57,9 +57,9 @@ pub enum CommitQCVerifyError {
 /// Error returned by `CommitQC::add()`.
 #[derive(thiserror::Error, Debug)]
 pub enum CommitQCAddError {
-    /// Inconsistent views.
-    #[error("Trying to add a message from a different view")]
-    InconsistentViews,
+    /// Inconsistent messages.
+    #[error("Trying to add signature for a different message")]
+    InconsistentMessages,
     /// Signer not present in the committee.
     #[error("Signer not in committee: {signer:?}")]
     SignerNotInCommittee {
@@ -100,7 +100,7 @@ impl CommitQC {
     ) -> Result<(), CommitQCAddError> {
         use CommitQCAddError as Error;
         if self.message != msg.msg {
-            return Err(Error::InconsistentViews);
+            return Err(Error::InconsistentMessages);
         };
         let Some(i) = genesis.committee.index(&msg.key) else {
             return Err(Error::SignerNotInCommittee {

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -58,7 +58,7 @@ pub enum CommitQCVerifyError {
 #[derive(thiserror::Error, Debug)]
 pub enum CommitQCAddError {
     /// Inconsistent views.
-    #[error("Trying to add a message from a diferent view")]
+    #[error("Trying to add a message from a different view")]
     InconsistentViews,
     /// Signer not present in the committee.
     #[error("Signer not in committee: {signer:?}")]

--- a/node/libs/roles/src/validator/messages/leader_commit.rs
+++ b/node/libs/roles/src/validator/messages/leader_commit.rs
@@ -73,6 +73,7 @@ pub enum CommitQCAddError {
         existing_message: Box<ReplicaCommit>,
     },
 }
+
 impl CommitQC {
     /// Header of the certified block.
     pub fn header(&self) -> &BlockHeader {

--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -50,7 +50,7 @@ pub enum PrepareQCVerifyError {
 #[derive(thiserror::Error, Debug)]
 pub enum PrepareQCAddError {
     /// Inconsistent views.
-    #[error("Trying to add a message from a diferent view")]
+    #[error("Trying to add a message from a different view")]
     InconsistentViews,
     /// Signer not present in the committee.
     #[error("Signer not in committee: {signer:?}")]

--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -50,7 +50,7 @@ pub enum PrepareQCVerifyError {
 #[derive(thiserror::Error, Debug)]
 pub enum PrepareQCAddError {
     /// Inconsistent views.
-    #[error("inconsistent views of signed messages")]
+    #[error("Trying to add a message from a diferent view")]
     InconsistentViews,
     /// Validator not present in the committee.
     #[error("Validator not in committee: {signer:?}")]

--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -52,9 +52,9 @@ pub enum PrepareQCAddError {
     /// Inconsistent views.
     #[error("Trying to add a message from a diferent view")]
     InconsistentViews,
-    /// Validator not present in the committee.
-    #[error("Validator not in committee: {signer:?}")]
-    ValidatorNotInCommittee {
+    /// Signer not present in the committee.
+    #[error("Signer not in committee: {signer:?}")]
+    SignerNotInCommittee {
         /// Signer of the message.
         signer: Box<validator::PublicKey>,
     },
@@ -111,7 +111,7 @@ impl PrepareQC {
             return Err(Error::InconsistentViews);
         }
         let Some(i) = genesis.committee.index(&msg.key) else {
-            return Err(Error::ValidatorNotInCommittee {
+            return Err(Error::SignerNotInCommittee {
                 signer: Box::new(msg.key.clone()),
             });
         };

--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -46,6 +46,26 @@ pub enum PrepareQCVerifyError {
     BadSignature(#[source] anyhow::Error),
 }
 
+/// Error returned by `PrepareQC::add()`.
+#[derive(thiserror::Error, Debug)]
+pub enum PrepareQCAddError {
+    /// Inconsistent views.
+    #[error("inconsistent views of signed messages")]
+    InconsistentViews,
+    /// Validator not present in the committee.
+    #[error("Validator not in committee: {signer:?}")]
+    ValidatorNotInCommittee {
+        /// Signer of the message.
+        signer: Box<validator::PublicKey>,
+    },
+    /// Message already present in PrepareQC.
+    #[error("Message already signed for PrepareQC: {existing_message:?}")]
+    Exists {
+        /// Existing message from the same replica.
+        existing_message: Box<ReplicaPrepare>,
+    },
+}
+
 impl PrepareQC {
     /// Create a new empty instance for a given `ReplicaCommit` message and a validator set size.
     pub fn new(view: View) -> Self {
@@ -80,24 +100,33 @@ impl PrepareQC {
 
     /// Add a validator's signed message.
     /// Message is assumed to be already verified.
-    // TODO: check if there is already a message from that validator.
     // TODO: verify the message inside instead.
-    pub fn add(&mut self, msg: &Signed<ReplicaPrepare>, genesis: &Genesis) {
+    pub fn add(
+        &mut self,
+        msg: &Signed<ReplicaPrepare>,
+        genesis: &Genesis,
+    ) -> Result<(), PrepareQCAddError> {
+        use PrepareQCAddError as Error;
         if msg.msg.view != self.view {
-            return;
+            return Err(Error::InconsistentViews);
         }
         let Some(i) = genesis.committee.index(&msg.key) else {
-            return;
+            return Err(Error::ValidatorNotInCommittee {
+                signer: Box::new(msg.key.clone()),
+            });
         };
         let e = self
             .map
             .entry(msg.msg.clone())
             .or_insert_with(|| Signers::new(genesis.committee.len()));
         if e.0[i] {
-            return;
+            return Err(Error::Exists {
+                existing_message: Box::new(msg.msg.clone()),
+            });
         };
         e.0.set(i, true);
         self.signature.add(&msg.sig);
+        Ok(())
     }
 
     /// Verifies the integrity of the PrepareQC.

--- a/node/libs/roles/src/validator/messages/tests.rs
+++ b/node/libs/roles/src/validator/messages/tests.rs
@@ -192,7 +192,8 @@ mod version1 {
         let replica_commit = replica_commit();
         let mut x = CommitQC::new(replica_commit.clone(), &genesis);
         for k in keys() {
-            x.add(&k.sign_msg(replica_commit.clone()), &genesis);
+            x.add(&k.sign_msg(replica_commit.clone()), &genesis)
+                .unwrap();
         }
         x
     }
@@ -219,7 +220,8 @@ mod version1 {
         let genesis = genesis();
         let replica_prepare = replica_prepare();
         for k in keys() {
-            x.add(&k.sign_msg(replica_prepare.clone()), &genesis);
+            x.add(&k.sign_msg(replica_prepare.clone()), &genesis)
+                .unwrap();
         }
         x
     }

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -99,10 +99,12 @@ impl Setup {
         let msg = ReplicaCommit { view, proposal };
         let mut justification = CommitQC::new(msg, &self.0.genesis);
         for key in &self.0.keys {
-            justification.add(
-                &key.sign_msg(justification.message.clone()),
-                &self.0.genesis,
-            );
+            justification
+                .add(
+                    &key.sign_msg(justification.message.clone()),
+                    &self.0.genesis,
+                )
+                .unwrap();
         }
         self.0.blocks.push(FinalBlock {
             payload,

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -190,7 +190,8 @@ fn make_replica_commit(rng: &mut impl Rng, view: ViewNumber, setup: &Setup) -> R
 fn make_commit_qc(rng: &mut impl Rng, view: ViewNumber, setup: &Setup) -> CommitQC {
     let mut qc = CommitQC::new(make_replica_commit(rng, view, setup), &setup.genesis);
     for key in &setup.keys {
-        qc.add(&key.sign_msg(qc.message.clone()), &setup.genesis);
+        qc.add(&key.sign_msg(qc.message.clone()), &setup.genesis)
+            .unwrap();
     }
     qc
 }
@@ -227,7 +228,8 @@ fn test_commit_qc() {
         let view = rng.gen();
         let mut qc = CommitQC::new(make_replica_commit(rng, view, &setup1), &setup1.genesis);
         for key in &setup1.keys[0..i] {
-            qc.add(&key.sign_msg(qc.message.clone()), &setup1.genesis);
+            qc.add(&key.sign_msg(qc.message.clone()), &setup1.genesis)
+                .unwrap();
         }
         let expected_weight = i as u64 * validator_weight;
         if expected_weight >= setup1.genesis.committee.threshold() {
@@ -269,7 +271,8 @@ fn test_prepare_qc() {
             qc.add(
                 &key.sign_msg(msgs.choose(rng).unwrap().clone()),
                 &setup1.genesis,
-            );
+            )
+            .unwrap();
         }
         let expected_weight = n as u64 * setup1.genesis.committee.total_weight() / 6;
         if expected_weight >= setup1.genesis.committee.threshold() {
@@ -302,7 +305,7 @@ fn test_validator_committee_weights() {
     let mut qc = PrepareQC::new(msg.view.clone());
     for (n, weight) in sums.iter().enumerate() {
         let key = &setup.keys[n];
-        qc.add(&key.sign_msg(msg.clone()), &setup.genesis);
+        qc.add(&key.sign_msg(msg.clone()), &setup.genesis).unwrap();
         let signers = &qc.map[&msg];
         assert_eq!(setup.genesis.committee.weight(signers), *weight);
     }

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -267,7 +267,7 @@ fn test_commit_qc_add_errors() {
     msg1.view.number = view.next();
     assert_matches!(
         qc.add(&setup.keys[0].sign_msg(msg1), &setup.genesis),
-        Err(Error::InconsistentViews { .. })
+        Err(Error::InconsistentMessages { .. })
     );
 
     // Try to add a message from a signer not in committee


### PR DESCRIPTION
## What ❔

Refactored the code to return errors on `PrepareQC::add` and `CommitQC::add`. We were just ignoring messages from different views, or signed by replicas not in the committee, or signed twice. Now these scenarios return an error.

## Why ❔

From a code review it was suggested to return errors in `PrepareQC::add` and `CommitQC::add` instead of ignoring the message. FWIW, these cases are already been checked by our current caller, but for correctness we believe these functions should provide proper errors in case addition to the QC is not performed.