### PR TITLE
Added comment explaining discrepancy in the field names.

### DIFF
--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -175,14 +175,17 @@ message Signed {
 }
 
 message PublicKey {
+  // The name is wrong, it should be bls12_381.
   optional bytes bn254 = 1; // required
 }
 
 message Signature {
+  // The name is wrong, it should be bls12_381.
   optional bytes bn254 = 1; // required
 }
 
 message AggregateSignature {
+  // The name is wrong, it should be bls12_381.
   optional bytes bn254 = 1; // required
 }
 


### PR DESCRIPTION
When changing the crypto keys back from bn254 to bls12_381, we forgot to rename the proto fields as well. It is not feasible to do it now, because of backward compatibility, so I've just added comments to explain the discrepancy. 