### PR TITLE
BFT-463: Add LeaderSelectionMode::Rota

### DIFF
--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -25,12 +25,16 @@ message LeaderSelectionMode {
     RoundRobin round_robin = 1;
     Sticky sticky = 2;
     Weighted weighted = 3;
+    Rota rota = 4;
   }
   message RoundRobin{}
   message Sticky{
-    repeated PublicKey keys = 1; // required
+    optional PublicKey key = 1; // required
   }
   message Weighted{}
+  message Rota {
+    repeated PublicKey keys = 1; // required
+  }
 }
 
 

--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -28,7 +28,7 @@ message LeaderSelectionMode {
   }
   message RoundRobin{}
   message Sticky{
-    optional PublicKey key = 1; // required
+    repeated PublicKey keys = 1; // required
   }
   message Weighted{}
 }

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -59,8 +59,8 @@ pub enum LeaderSelectionMode {
     /// Select in a round-robin fashion, based on validators' index within the set.
     RoundRobin,
 
-    /// Select based on a sticky assignment to a specific validator.
-    Sticky(validator::PublicKey),
+    /// Select based on a sticky assignment to a non-empty list of specific validators.
+    Sticky(Vec<validator::PublicKey>),
 
     /// Select pseudo-randomly, based on validators' weights.
     Weighted,
@@ -174,8 +174,9 @@ impl Committee {
                 }
                 unreachable!()
             }
-            LeaderSelectionMode::Sticky(pk) => {
-                let index = self.index(pk).unwrap();
+            LeaderSelectionMode::Sticky(pks) => {
+                let index = view_number.0 as usize % pks.len();
+                let index = self.index(&pks[index]).unwrap();
                 self.get(index).unwrap().key.clone()
             }
         }
@@ -309,9 +310,13 @@ impl fmt::Debug for Genesis {
 impl Genesis {
     /// Verifies correctness.
     pub fn verify(&self) -> anyhow::Result<()> {
-        if let LeaderSelectionMode::Sticky(pk) = &self.leader_selection {
-            if self.validators.index(pk).is_none() {
-                anyhow::bail!("leader_selection sticky mode public key is not in committee");
+        if let LeaderSelectionMode::Sticky(pks) = &self.leader_selection {
+            for pk in pks {
+                if self.validators.index(pk).is_none() {
+                    anyhow::bail!(
+                        "leader_selection sticky mode public key is not in committee: {pk:?}"
+                    );
+                }
             }
         }
 

--- a/node/libs/roles/src/validator/messages/tests.rs
+++ b/node/libs/roles/src/validator/messages/tests.rs
@@ -92,14 +92,21 @@ fn test_sticky() {
     let ctx = ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
     let committee = validator_committee();
-    let want = committee
-        .get(rng.gen_range(0..committee.len()))
-        .unwrap()
-        .key
-        .clone();
+    let mut want = Vec::new();
+    for _ in 0..3 {
+        want.push(
+            committee
+                .get(rng.gen_range(0..committee.len()))
+                .unwrap()
+                .key
+                .clone(),
+        );
+    }
     let sticky = LeaderSelectionMode::Sticky(want.clone());
     for _ in 0..100 {
-        assert_eq!(want, committee.view_leader(rng.gen(), &sticky));
+        let vn: ViewNumber = rng.gen();
+        let pk = &want[vn.0 as usize % want.len()];
+        assert_eq!(*pk, committee.view_leader(vn, &sticky));
     }
 }
 
@@ -203,7 +210,7 @@ mod version1 {
     fn genesis_verify_leader_pubkey_not_in_committee() {
         let mut rng = StdRng::seed_from_u64(29483920);
         let mut genesis = rng.gen::<GenesisRaw>();
-        genesis.leader_selection = LeaderSelectionMode::Sticky(rng.gen());
+        genesis.leader_selection = LeaderSelectionMode::Sticky(vec![rng.gen()]);
         let genesis = genesis.with_hash();
         assert!(genesis.verify().is_err())
     }

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -267,9 +267,10 @@ impl Distribution<GenesisHash> for Standard {
 
 impl Distribution<LeaderSelectionMode> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> LeaderSelectionMode {
-        match rng.gen_range(0..=2) {
+        match rng.gen_range(0..=3) {
             0 => LeaderSelectionMode::RoundRobin,
-            1 => LeaderSelectionMode::Sticky({
+            1 => LeaderSelectionMode::Sticky(rng.gen()),
+            3 => LeaderSelectionMode::Rota({
                 let n = rng.gen_range(1..=3);
                 rng.sample_iter(Standard).take(n).collect()
             }),

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -269,7 +269,10 @@ impl Distribution<LeaderSelectionMode> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> LeaderSelectionMode {
         match rng.gen_range(0..=2) {
             0 => LeaderSelectionMode::RoundRobin,
-            1 => LeaderSelectionMode::Sticky(rng.gen()),
+            1 => LeaderSelectionMode::Sticky({
+                let n = rng.gen_range(1..=3);
+                rng.sample_iter(Standard).take(n).collect()
+            }),
             _ => LeaderSelectionMode::Weighted,
         }
     }

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -104,7 +104,7 @@ fn test_genesis_verify() {
     assert!(Genesis::read(&genesis.build()).is_ok());
 
     let mut genesis = (*genesis).clone();
-    genesis.leader_selection = LeaderSelectionMode::Sticky(vec![rng.gen()]);
+    genesis.leader_selection = LeaderSelectionMode::Sticky(rng.gen());
     let genesis = genesis.with_hash();
     assert!(genesis.verify().is_err());
     assert!(Genesis::read(&genesis.build()).is_err())

--- a/node/libs/roles/src/validator/tests.rs
+++ b/node/libs/roles/src/validator/tests.rs
@@ -104,7 +104,7 @@ fn test_genesis_verify() {
     assert!(Genesis::read(&genesis.build()).is_ok());
 
     let mut genesis = (*genesis).clone();
-    genesis.leader_selection = LeaderSelectionMode::Sticky(rng.gen());
+    genesis.leader_selection = LeaderSelectionMode::Sticky(vec![rng.gen()]);
     let genesis = genesis.with_hash();
     assert!(genesis.verify().is_err());
     assert!(Genesis::read(&genesis.build()).is_err())

--- a/node/tools/src/tests.rs
+++ b/node/tools/src/tests.rs
@@ -11,10 +11,14 @@ impl Distribution<AppConfig> for EncodeDist {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AppConfig {
         let mut genesis: validator::GenesisRaw = rng.gen();
         // In order for the genesis to be valid, the sticky leader needs to be in the validator committee.
-        if let LeaderSelectionMode::Sticky(_) = genesis.leader_selection {
-            let i = rng.gen_range(0..genesis.validators.len());
-            genesis.leader_selection =
-                LeaderSelectionMode::Sticky(genesis.validators.get(i).unwrap().key.clone());
+        if let LeaderSelectionMode::Sticky(pks) = genesis.leader_selection {
+            let n = pks.len();
+            let i = rng.gen_range(0..genesis.committee.len());
+            let mut pks = Vec::new();
+            for _ in 0..n {
+                pks.push(genesis.validators.get(i).unwrap().key.clone());
+            }
+            genesis.leader_selection = LeaderSelectionMode::Sticky(pks);
         }
         AppConfig {
             server_addr: self.sample(rng),

--- a/node/tools/src/tests.rs
+++ b/node/tools/src/tests.rs
@@ -11,14 +11,18 @@ impl Distribution<AppConfig> for EncodeDist {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AppConfig {
         let mut genesis: validator::GenesisRaw = rng.gen();
         // In order for the genesis to be valid, the sticky leader needs to be in the validator committee.
-        if let LeaderSelectionMode::Sticky(pks) = genesis.leader_selection {
+        if let LeaderSelectionMode::Sticky(_) = genesis.leader_selection {
+            let i = rng.gen_range(0..genesis.validators.len());
+            genesis.leader_selection =
+                LeaderSelectionMode::Sticky(genesis.validators.get(i).unwrap().key.clone());
+        } else if let LeaderSelectionMode::Rota(pks) = genesis.leader_selection {
             let n = pks.len();
-            let i = rng.gen_range(0..genesis.committee.len());
+            let i = rng.gen_range(0..genesis.validators.len());
             let mut pks = Vec::new();
             for _ in 0..n {
                 pks.push(genesis.validators.get(i).unwrap().key.clone());
             }
-            genesis.leader_selection = LeaderSelectionMode::Sticky(pks);
+            genesis.leader_selection = LeaderSelectionMode::Rota(pks);
         }
         AppConfig {
             server_addr: self.sample(rng),


### PR DESCRIPTION
## What ❔

Adds a `LeaderSelectionMode::Rota` to allow specifying leaders in subsequent views using a list of public keys. The 1st validator on the list is going to be the leader in view 0, the 2nd in view 1, the 3rd in view 2, wrapping around to start from the beginning as the views increase. There can be repeated keys on the list, and they all have to be part of the committee. 

## Why ❔

This is part of BFT-439 to modify the BFT tests to use the approach outlined in the [Twins paper](https://arxiv.org/abs/2004.10617). Part of that is the ability to control who is the leader in each of the views. 

With this change we should be able to generate a fixed leader schedule for the first few rounds of a protocol. The implementation wraps around so it's a total function, but in practice the tests will provide leaders for all the rounds executed in the test.

### Why not modify `Sticky`?

I thought about whether I should add a new variant to `LeaderSelectionMode` or modify `LeaderSelectionMode::Sticky` to allow multiple values. On the Protobuf bytecode level they should be compatible, and I thought `Sticky` is probably used mostly in tests. 

Based on the answers in the comments below, this is not the case, and it is in fact used in production to represent the centralised sequencer. The genesis it is part of is stored in Postgres as JSONB, so changes in the key name would not be backwards compatible. The `protobuf_conformance` workflow correctly highlighted this regression 🎉 