### PR TITLE
BFT-465: Twins tests

### DIFF
--- a/node/actors/bft/src/testonly/node.rs
+++ b/node/actors/bft/src/testonly/node.rs
@@ -62,6 +62,7 @@ impl Node {
         let mut con_recv = consensus_pipe.recv;
         let con_send = consensus_pipe.send;
         scope::run!(ctx, |ctx, s| async {
+            // Run the consensus actor
             s.spawn(async {
                 let validator_key = self.net.validator_key.clone().unwrap();
                 crate::Config {
@@ -75,6 +76,8 @@ impl Node {
                 .await
                 .context("consensus.run()")
             });
+            // Forward input messages received from the network to the actor;
+            // turns output from others to input for this instance.
             s.spawn(async {
                 while let Ok(network_message) = net_recv.recv(ctx).await {
                     match network_message {
@@ -85,6 +88,8 @@ impl Node {
                 }
                 Ok(())
             });
+            // Forward output messages from the actor to the network;
+            // turns output from this to inputs for others.
             // Get the next message from the channel. Our response depends on what type of replica we are.
             while let Ok(msg) = con_recv.recv(ctx).await {
                 match msg {

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -1,4 +1,5 @@
 use super::{Behavior, Node};
+use anyhow::bail;
 use network::{io, Config};
 use rand::prelude::SliceRandom;
 use std::{
@@ -377,6 +378,12 @@ async fn twins_receive_loop(
         // If the view is higher than what we have planned for, assume no partitions.
         // Every node is guaranteed to be present in only one partition.
         let partitions_opt = splits.get(view_number);
+
+        if partitions_opt.is_none() {
+            bail!(
+                "ran out of scheduled rounds; most likely cannot finalize blocks even if we go on"
+            );
+        }
 
         let msg = || {
             io::OutputMessage::Consensus(io::ConsensusReq {

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -92,9 +92,15 @@ impl Test {
             // Check that the stored blocks are consistent.
             for i in 0..self.blocks_to_finalize as u64 {
                 let i = first + i;
-                let want = honest[0].block(ctx, i).await?;
+                // Only comparing the payload; the signatories might be different,
+                // at least with the simulated gossip of the twins network.
+                let want = honest[0]
+                    .block(ctx, i)
+                    .await?
+                    .expect("checked its existence")
+                    .payload;
                 for store in &honest[1..] {
-                    assert_eq!(want, store.block(ctx, i).await?);
+                    assert_eq!(want, store.block(ctx, i).await?.unwrap().payload);
                 }
             }
             Ok(())

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -1,18 +1,23 @@
 use super::{Behavior, Node};
 use network::{io, Config};
 use rand::prelude::SliceRandom;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use tracing::Instrument as _;
 use zksync_concurrency::{
     ctx::{
         self,
-        channel::{UnboundedReceiver, UnboundedSender},
+        channel::{self, UnboundedReceiver, UnboundedSender},
     },
     oneshot, scope,
 };
 use zksync_consensus_network as network;
-use zksync_consensus_roles::validator::{self, Genesis, PublicKey};
-use zksync_consensus_storage::testonly::new_store;
+use zksync_consensus_roles::validator::{
+    self, BlockNumber, CommitQC, ConsensusMsg, Genesis, PublicKey,
+};
+use zksync_consensus_storage::{testonly::new_store, BlockStore};
 use zksync_consensus_utils::pipe;
 
 #[derive(Clone)]
@@ -200,6 +205,10 @@ async fn run_nodes_twins(
         // Inbox of the consensus instances, indexed by their network identity,
         // so that we can send to the one which is in the same partition as the sender.
         let mut sends = HashMap::new();
+        // Blockstores of nodes, indexed by port; used to simulate the effect of gossip.
+        let mut stores = HashMap::new();
+        // Outbound gossip relationships to simulate the effects of block fetching.
+        let mut gossip_targets = HashMap::new();
 
         for (i, spec) in specs.iter().enumerate() {
             let (actor_pipe, dispatcher_pipe) = pipe::new();
@@ -210,6 +219,19 @@ async fn run_nodes_twins(
 
             sends.insert(port, actor_pipe.send);
             recvs.push((port, actor_pipe.recv));
+            stores.insert(port, spec.block_store.clone());
+            gossip_targets.insert(
+                port,
+                spec.net
+                    .gossip
+                    .static_outbound
+                    .values()
+                    .map(|host| {
+                        let addr: std::net::SocketAddr = host.0.parse().expect("valid address");
+                        addr.port()
+                    })
+                    .collect(),
+            );
 
             // Run consensus; the dispatcher pipe is its network connection, which means we can use the actor pipe to:
             // * send Output messages from other actors to this consensus instance
@@ -225,20 +247,36 @@ async fn run_nodes_twins(
         // Taking these refeferences is necessary for the `scope::run!` environment lifetime rules to compile
         // with `async move`, which in turn is necessary otherwise it the spawned process could not borrow `port`.
         // Potentially `ctx::NoCopy` could be used with `port`.
-        let sends = &sends;
         let validator_ports = &validator_ports;
+        let sends = &sends;
+        let stores = &stores;
+        let gossip_targets = &gossip_targets;
+        let (gossip_send, gossip_recv) = channel::unbounded();
 
         // Run networks by receiving from all consensus instances:
         // * identify the view they are in from the message
         // * identify the partition they are in based on their network id
         // * either broadcast to all other instances in the partition, or find out the network
         //   identity of the target validator and send to it _iff_ they are in the same partition
+        // * simulating the gossiping of finalized blockss
         scope::run!(ctx, |ctx, s| async move {
             for (port, recv) in recvs {
+                let gossip_send = gossip_send.clone();
                 s.spawn(async move {
-                    twins_receive_loop(ctx, port, recv, sends, validator_ports, splits).await
+                    twins_receive_loop(
+                        ctx,
+                        splits,
+                        validator_ports,
+                        sends,
+                        &gossip_targets[&port],
+                        gossip_send,
+                        port,
+                        recv,
+                    )
+                    .await
                 });
             }
+            s.spawn(async { twins_gossip_loop(ctx, stores, gossip_recv).await });
             anyhow::Ok(())
         })
         .await
@@ -248,16 +286,31 @@ async fn run_nodes_twins(
 
 /// Receive input messages from the consensus actor and send them to the others
 /// according to the partition schedule of the port associated with this instance.
+///
+/// We have to simulate the gossip layer which isn't instantiated by these tests.
+/// If we don't, then if a replica misses a LeaderPrepare message it won't ever get the payload
+/// and won't be able to finalize the block, and won't participate further in the consensus.
+#[allow(clippy::too_many_arguments)]
 async fn twins_receive_loop(
     ctx: &ctx::Ctx,
+    splits: &PortSplitSchedule,
+    validator_ports: &HashMap<PublicKey, Vec<Port>>,
+    sends: &HashMap<Port, UnboundedSender<io::OutputMessage>>,
+    gossip_targets: &HashSet<Port>,
+    gossip_send: UnboundedSender<(Port, Port, BlockNumber)>,
     port: Port,
     mut recv: UnboundedReceiver<io::InputMessage>,
-    sends: &HashMap<Port, UnboundedSender<io::OutputMessage>>,
-    validator_ports: &HashMap<PublicKey, Vec<Port>>,
-    splits: &PortSplitSchedule,
 ) -> anyhow::Result<()> {
     let rng = &mut ctx.rng();
     let start = &ctx.now();
+
+    // Finalized block number iff this node can gossip to the target and the message contains a QC.
+    let block_to_gossip = |target_port: Port, msg: &io::OutputMessage| {
+        if !gossip_targets.contains(&target_port) {
+            return None;
+        }
+        output_msg_commit_qc(msg).map(|qc| qc.header().number)
+    };
 
     // We need to buffer messages that cannot be delivered due to partitioning, and deliver them later.
     // The spec says that the network is expected to deliver messages eventually, potentially out of order,
@@ -293,6 +346,14 @@ async fn twins_receive_loop(
         if can_send {
             let s = &sends[&target_port];
 
+            // Send after taking note of potentially gossipable blocks.
+            let send = |msg| {
+                if let Some(bn) = block_to_gossip(target_port, &msg) {
+                    gossip_send.send((port, target_port, bn));
+                }
+                s.send(msg);
+            };
+
             // Messages can be delivered in arbitrary order.
             stash.shuffle(rng);
 
@@ -300,17 +361,13 @@ async fn twins_receive_loop(
                 let view = output_msg_view_number(&unstashed);
                 let kind = output_msg_label(&unstashed);
                 eprintln!("   ^^^ unstashed view={view} from={port} to={target_port} kind={kind}");
-                s.send(unstashed);
+                send(unstashed);
             }
             eprintln!("   >>> sending view={view} from={port} to={target_port} kind={kind}");
-            s.send(msg);
-            // TODO: If the message is a LeaderPrepare then remember the block sent,
-            //       then if the next message is a LeaderCommit with a CommitQC then
-            //       prepare a FinalBlock and pretend that we have a gossip layer by
-            //       by calling block_store.queue_block on every other node.
+            send(msg);
         } else {
             eprintln!("   VVV stashed view={view} from={port} to={target_port} kind={kind}");
-            stash.push(msg)
+            stash.push(msg);
         }
     };
 
@@ -376,6 +433,37 @@ async fn twins_receive_loop(
     Ok(())
 }
 
+/// Simulate the effects of gossip: if the source node can gossip to the target,
+/// and the message being sent contains a CommitQC, and the sender has the
+/// referenced finalized block in its store, then assume that the target
+/// could fetch this block if they wanted, and insert it directly into their store.
+///
+/// This happens concurrently with the actual message passing, so it's just an
+/// approximation. It also happens out of order. This method only contains the
+/// send loop, to deal with the spawning of store operations.
+async fn twins_gossip_loop(
+    ctx: &ctx::Ctx,
+    stores: &HashMap<Port, Arc<BlockStore>>,
+    mut recv: UnboundedReceiver<(Port, Port, BlockNumber)>,
+) -> anyhow::Result<()> {
+    scope::run!(ctx, |ctx, s| async move {
+        while let Ok((from, to, number)) = recv.recv(ctx).await {
+            // Perform the storage operations asynchronously because `queue_block` will
+            // wait for all dependencies to be inserted first.
+            s.spawn_bg(async move {
+                let local_store = &stores[&from];
+                let remote_store = &stores[&to];
+                if let Ok(Some(block)) = local_store.block(ctx, number).await {
+                    let _ = remote_store.queue_block(ctx, block).await;
+                }
+                Ok(())
+            });
+        }
+        Ok(())
+    })
+    .await
+}
+
 fn output_msg_view_number(msg: &io::OutputMessage) -> u64 {
     match msg {
         io::OutputMessage::Consensus(cr) => cr.msg.msg.view().number.0,
@@ -385,5 +473,16 @@ fn output_msg_view_number(msg: &io::OutputMessage) -> u64 {
 fn output_msg_label(msg: &io::OutputMessage) -> &str {
     match msg {
         io::OutputMessage::Consensus(cr) => cr.msg.msg.label(),
+    }
+}
+
+fn output_msg_commit_qc(msg: &io::OutputMessage) -> Option<&CommitQC> {
+    match msg {
+        io::OutputMessage::Consensus(cr) => match &cr.msg.msg {
+            ConsensusMsg::ReplicaPrepare(rp) => rp.high_qc.as_ref(),
+            ConsensusMsg::LeaderPrepare(lp) => lp.justification.high_qc(),
+            ConsensusMsg::ReplicaCommit(_) => None,
+            ConsensusMsg::LeaderCommit(lc) => Some(&lc.justification),
+        },
     }
 }

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -83,84 +83,87 @@ impl Test {
 
 /// Run a set of nodes.
 async fn run_nodes(ctx: &ctx::Ctx, network: Network, specs: &[Node]) -> anyhow::Result<()> {
+    match network {
+        Network::Real => run_nodes_real(ctx, specs).await,
+        Network::Mock => run_nodes_mock(ctx, specs).await,
+    }
+}
+
+/// Run a set of nodes with a real network.
+async fn run_nodes_real(ctx: &ctx::Ctx, specs: &[Node]) -> anyhow::Result<()> {
     scope::run!(ctx, |ctx, s| async {
-        match network {
-            Network::Real => {
-                let mut nodes = vec![];
-                for (i, spec) in specs.iter().enumerate() {
-                    let (node, runner) = network::testonly::Instance::new(
-                        spec.net.clone(),
-                        spec.block_store.clone(),
-                    );
-                    s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("node", i)));
-                    nodes.push(node);
+        let mut nodes = vec![];
+        for (i, spec) in specs.iter().enumerate() {
+            let (node, runner) =
+                network::testonly::Instance::new(spec.net.clone(), spec.block_store.clone());
+            s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("node", i)));
+            nodes.push(node);
+        }
+        network::testonly::instant_network(ctx, nodes.iter()).await?;
+        for (i, node) in nodes.into_iter().enumerate() {
+            let spec = &specs[i];
+            s.spawn(
+                async {
+                    let mut node = node;
+                    spec.run(ctx, node.pipe()).await
                 }
-                network::testonly::instant_network(ctx, nodes.iter()).await?;
-                for (i, node) in nodes.into_iter().enumerate() {
-                    let spec = &specs[i];
-                    s.spawn(
-                        async {
-                            let mut node = node;
-                            spec.run(ctx, node.pipe()).await
-                        }
-                        .instrument(tracing::info_span!("node", i)),
-                    );
-                }
-            }
-            Network::Mock => {
-                // Actor inputs, ie. where the test can send messages to the consensus.
-                let mut sends = HashMap::new();
-                // Actor outputs, ie. the messages the actor wants to send to the others.
-                let mut recvs = vec![];
-                for (i, spec) in specs.iter().enumerate() {
-                    let (actor_pipe, dispatcher_pipe) = pipe::new();
-                    let key = spec.net.validator_key.as_ref().unwrap().public();
-                    sends.insert(key, actor_pipe.send);
-                    recvs.push(actor_pipe.recv);
-                    // Run consensus; the dispatcher pipe is its network connection,
-                    // which means we can use the actor pipe to:
-                    // * send Output messages from other actors to this consensus instance
-                    // * receive Input messages sent by this consensus to the other actors
-                    s.spawn(
-                        async {
-                            let mut network_pipe = dispatcher_pipe;
-                            spec.run(ctx, &mut network_pipe).await
-                        }
-                        .instrument(tracing::info_span!("node", i)),
-                    );
-                }
-                // Run mock networks by receiving the output-turned-input from all consensus
-                // instances and forwarding them to the others.
-                scope::run!(ctx, |ctx, s| async {
-                    for recv in recvs {
-                        s.spawn(async {
-                            use zksync_consensus_network::io;
-                            let mut recv = recv;
-                            while let Ok(io::InputMessage::Consensus(message)) =
-                                recv.recv(ctx).await
-                            {
-                                let msg = || {
-                                    io::OutputMessage::Consensus(io::ConsensusReq {
-                                        msg: message.message.clone(),
-                                        ack: oneshot::channel().0,
-                                    })
-                                };
-                                match message.recipient {
-                                    io::Target::Validator(v) => sends.get(&v).unwrap().send(msg()),
-                                    io::Target::Broadcast => {
-                                        sends.values().for_each(|s| s.send(msg()))
-                                    }
-                                }
-                            }
-                            Ok(())
-                        });
-                    }
-                    anyhow::Ok(())
-                })
-                .await?;
-            }
+                .instrument(tracing::info_span!("node", i)),
+            );
         }
         Ok(())
+    })
+    .await
+}
+
+/// Run a set of nodes with a mock network.
+async fn run_nodes_mock(ctx: &ctx::Ctx, specs: &[Node]) -> anyhow::Result<()> {
+    scope::run!(ctx, |ctx, s| async {
+        // Actor inputs, ie. where the test can send messages to the consensus.
+        let mut sends = HashMap::new();
+        // Actor outputs, ie. the messages the actor wants to send to the others.
+        let mut recvs = vec![];
+        for (i, spec) in specs.iter().enumerate() {
+            let (actor_pipe, dispatcher_pipe) = pipe::new();
+            let key = spec.net.validator_key.as_ref().unwrap().public();
+            sends.insert(key, actor_pipe.send);
+            recvs.push(actor_pipe.recv);
+            // Run consensus; the dispatcher pipe is its network connection,
+            // which means we can use the actor pipe to:
+            // * send Output messages from other actors to this consensus instance
+            // * receive Input messages sent by this consensus to the other actors
+            s.spawn(
+                async {
+                    let mut network_pipe = dispatcher_pipe;
+                    spec.run(ctx, &mut network_pipe).await
+                }
+                .instrument(tracing::info_span!("node", i)),
+            );
+        }
+        // Run mock networks by receiving the output-turned-input from all consensus
+        // instances and forwarding them to the others.
+        scope::run!(ctx, |ctx, s| async {
+            for recv in recvs {
+                s.spawn(async {
+                    use zksync_consensus_network::io;
+                    let mut recv = recv;
+                    while let Ok(io::InputMessage::Consensus(message)) = recv.recv(ctx).await {
+                        let msg = || {
+                            io::OutputMessage::Consensus(io::ConsensusReq {
+                                msg: message.message.clone(),
+                                ack: oneshot::channel().0,
+                            })
+                        };
+                        match message.recipient {
+                            io::Target::Validator(v) => sends.get(&v).unwrap().send(msg()),
+                            io::Target::Broadcast => sends.values().for_each(|s| s.send(msg())),
+                        }
+                    }
+                    Ok(())
+                });
+            }
+            anyhow::Ok(())
+        })
+        .await
     })
     .await
 }

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -3,9 +3,15 @@ use network::{io, Config};
 use rand::prelude::SliceRandom;
 use std::collections::{HashMap, HashSet};
 use tracing::Instrument as _;
-use zksync_concurrency::{ctx, oneshot, scope};
+use zksync_concurrency::{
+    ctx::{
+        self,
+        channel::{UnboundedReceiver, UnboundedSender},
+    },
+    oneshot, scope,
+};
 use zksync_consensus_network as network;
-use zksync_consensus_roles::validator::{self, Genesis};
+use zksync_consensus_roles::validator::{self, Genesis, PublicKey};
 use zksync_consensus_storage::testonly::new_store;
 use zksync_consensus_utils::pipe;
 
@@ -218,134 +224,19 @@ async fn run_nodes_twins(
         }
         // Taking these refeferences is necessary for the `scope::run!` environment lifetime rules to compile
         // with `async move`, which in turn is necessary otherwise it the spawned process could not borrow `port`.
+        // Potentially `ctx::NoCopy` could be used with `port`.
         let sends = &sends;
         let validator_ports = &validator_ports;
-        let start = &ctx.now();
+
         // Run networks by receiving from all consensus instances:
         // * identify the view they are in from the message
         // * identify the partition they are in based on their network id
         // * either broadcast to all other instances in the partition, or find out the network
         //   identity of the target validator and send to it _iff_ they are in the same partition
         scope::run!(ctx, |ctx, s| async move {
-            for (port, mut recv) in recvs {
+            for (port, recv) in recvs {
                 s.spawn(async move {
-                    use zksync_consensus_network::io;
-                    let rng = &mut ctx.rng();
-
-                    // We need to buffer messages that cannot be delivered due to partitioning, and deliver them later.
-                    // The spec says that the network is expected to deliver messages eventually, potentially out of order,
-                    // caveated by the fact that the actual implementation only keep retrying the last message.
-                    // However with the actors instantiated in by this test, that would not be sufficient because
-                    // there is no gossip network here, and if a replica misses a proposal, it won't get it via gossip,
-                    // and will forever be unable to finalize blocks.
-                    // A separate issue is the definition of "later", without actually adding timing assumptions:
-                    // * If we want to allow partitions which don't have enough replicas for a quorum, and the replicas
-                    //   don't move on from a view until they reach quorum, then "later" could be defined by so many
-                    //   messages in a view that it indicates a timeout loop. NB the consensus might not actually have
-                    //   an actual timeout loop and might rely on the network trying to re-broadcast forever.
-                    // * OTOH if all partitions are at least quorum sized, then we there will be a subset of nodes that
-                    //   can move on to the next view, in which a new partition configuration will allow them to broadcast
-                    //   to previously isolated peers. 
-                    // * One idea is to wait until replica A wants to send to replica B in a view when they are no longer 
-                    //   partitioned, and then unstash all previous A-to-B messages. This would _not_ work with HotStuff
-                    //   out of the box, because replicas only communicate with their leader, so if for example B missed
-                    //   a LeaderCommit from A in an earlier view, B will not respond to the LeaderPrepare from C because
-                    //   they can't commit the earlier block until they get a new message from A. However since 
-                    //   https://github.com/matter-labs/era-consensus/pull/119 the ReplicaPrepare messages are broadcasted, 
-                    //   so we shouldn't have to wait long for A to unstash its messages to B.
-                    // * If that wouldn't be acceptable then we could have some kind of global view of stashed messages
-                    //   and unstash them as soon as someone moves on to a new view.
-                    let mut stashes: HashMap<Port, Vec<io::OutputMessage>> = HashMap::new();
-
-                    // Either stash a message, or unstash all messages and send them to the target along with the new one.
-                    let mut send_or_stash =
-                        |can_send: bool, target_port: Port, msg: io::OutputMessage| {
-                            let stash = stashes.entry(target_port).or_default();
-                            let view = output_msg_view_number(&msg);
-                            let kind = output_msg_label(&msg);
-
-                            if can_send {
-                                let s = &sends[&target_port];
-
-                                // Messages can be delivered in arbitrary order.
-                                stash.shuffle(rng);
-
-                                for unstashed in stash.drain(0..) {
-                                    let view = output_msg_view_number(&unstashed);
-                                    let kind = output_msg_label(&unstashed);
-                                    eprintln!("   ^^^ unstashed view={view} from={port} to={target_port} kind={kind}");
-                                    s.send(unstashed);
-                                }
-                                eprintln!("   >>> sending view={view} from={port} to={target_port} kind={kind}");
-                                s.send(msg);
-                            } else {
-                                eprintln!("   VVV stashed view={view} from={port} to={target_port} kind={kind}");
-                                stash.push(msg)
-                            }
-                        };
-
-                    while let Ok(io::InputMessage::Consensus(message)) = recv.recv(ctx).await {
-                        let view_number = message.message.msg.view().number.0 as usize;
-                        // Here we assume that all instances start from view 0 in the tests.
-                        // If the view is higher than what we have planned for, assume no partitions.
-                        // Every node is guaranteed to be present in only one partition.
-                        let partitions_opt = splits.get(view_number);
-
-                        let msg = || {
-                            io::OutputMessage::Consensus(io::ConsensusReq {
-                                msg: message.message.clone(),
-                                ack: oneshot::channel().0,
-                            })
-                        };
-
-                        match message.recipient {
-                            io::Target::Broadcast => match partitions_opt {
-                                None => {
-                                    eprintln!("broadcasting view={view_number} from={port} target=all");
-                                    for target_port in sends.keys() {
-                                        send_or_stash(true, *target_port, msg());
-                                    }
-                                }
-                                Some(ps) => {
-                                    for p in ps {                                        
-                                        let can_send = p.contains(&port);
-                                        eprintln!("broadcasting view={view_number} from={port} target={p:?} can_send={can_send} t={}", start.elapsed().as_seconds_f64());
-                                        for target_port in p {
-                                            send_or_stash(can_send, *target_port, msg());
-                                        }
-                                    }
-                                }
-                            },
-                            io::Target::Validator(v) => {
-                                let target_ports = &validator_ports[&v];
-
-                                match partitions_opt {
-                                    None => {
-                                        for target_port in target_ports {
-                                            eprintln!("unicasting view={view_number} from={port} target={target_port}");
-                                            send_or_stash(true, *target_port, msg());
-                                        }
-                                    }
-                                    Some(ps) => {
-                                        for p in ps {
-                                            let can_send = p.contains(&port);
-                                            for target_port in target_ports {
-                                                if p.contains(target_port) {
-                                                    eprintln!("unicasting view={view_number} from={port} target={target_port } can_send={can_send} t={}", start.elapsed().as_seconds_f64());
-                                                    send_or_stash(
-                                                        can_send,
-                                                        *target_port,
-                                                        msg(),
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
+                    twins_receive_loop(ctx, port, recv, sends, validator_ports, splits).await
                 });
             }
             anyhow::Ok(())
@@ -353,6 +244,136 @@ async fn run_nodes_twins(
         .await
     })
     .await
+}
+
+/// Receive input messages from the consensus actor and send them to the others
+/// according to the partition schedule of the port associated with this instance.
+async fn twins_receive_loop(
+    ctx: &ctx::Ctx,
+    port: Port,
+    mut recv: UnboundedReceiver<io::InputMessage>,
+    sends: &HashMap<Port, UnboundedSender<io::OutputMessage>>,
+    validator_ports: &HashMap<PublicKey, Vec<Port>>,
+    splits: &PortSplitSchedule,
+) -> anyhow::Result<()> {
+    let rng = &mut ctx.rng();
+    let start = &ctx.now();
+
+    // We need to buffer messages that cannot be delivered due to partitioning, and deliver them later.
+    // The spec says that the network is expected to deliver messages eventually, potentially out of order,
+    // caveated by the fact that the actual implementation only keep retrying the last message.
+    // However with the actors instantiated in by this test, that would not be sufficient because
+    // there is no gossip network here, and if a replica misses a proposal, it won't get it via gossip,
+    // and will forever be unable to finalize blocks.
+    // A separate issue is the definition of "later", without actually adding timing assumptions:
+    // * If we want to allow partitions which don't have enough replicas for a quorum, and the replicas
+    //   don't move on from a view until they reach quorum, then "later" could be defined by so many
+    //   messages in a view that it indicates a timeout loop. NB the consensus might not actually have
+    //   an actual timeout loop and might rely on the network trying to re-broadcast forever.
+    // * OTOH if all partitions are at least quorum sized, then we there will be a subset of nodes that
+    //   can move on to the next view, in which a new partition configuration will allow them to broadcast
+    //   to previously isolated peers.
+    // * One idea is to wait until replica A wants to send to replica B in a view when they are no longer
+    //   partitioned, and then unstash all previous A-to-B messages. This would _not_ work with HotStuff
+    //   out of the box, because replicas only communicate with their leader, so if for example B missed
+    //   a LeaderCommit from A in an earlier view, B will not respond to the LeaderPrepare from C because
+    //   they can't commit the earlier block until they get a new message from A. However since
+    //   https://github.com/matter-labs/era-consensus/pull/119 the ReplicaPrepare messages are broadcasted,
+    //   so we shouldn't have to wait long for A to unstash its messages to B.
+    // * If that wouldn't be acceptable then we could have some kind of global view of stashed messages
+    //   and unstash them as soon as someone moves on to a new view.
+    let mut stashes: HashMap<Port, Vec<io::OutputMessage>> = HashMap::new();
+
+    // Either stash a message, or unstash all messages and send them to the target along with the new one.
+    let mut send_or_stash = |can_send: bool, target_port: Port, msg: io::OutputMessage| {
+        let stash = stashes.entry(target_port).or_default();
+        let view = output_msg_view_number(&msg);
+        let kind = output_msg_label(&msg);
+
+        if can_send {
+            let s = &sends[&target_port];
+
+            // Messages can be delivered in arbitrary order.
+            stash.shuffle(rng);
+
+            for unstashed in stash.drain(0..) {
+                let view = output_msg_view_number(&unstashed);
+                let kind = output_msg_label(&unstashed);
+                eprintln!("   ^^^ unstashed view={view} from={port} to={target_port} kind={kind}");
+                s.send(unstashed);
+            }
+            eprintln!("   >>> sending view={view} from={port} to={target_port} kind={kind}");
+            s.send(msg);
+            // TODO: If the message is a LeaderPrepare then remember the block sent,
+            //       then if the next message is a LeaderCommit with a CommitQC then
+            //       prepare a FinalBlock and pretend that we have a gossip layer by
+            //       by calling block_store.queue_block on every other node.
+        } else {
+            eprintln!("   VVV stashed view={view} from={port} to={target_port} kind={kind}");
+            stash.push(msg)
+        }
+    };
+
+    while let Ok(io::InputMessage::Consensus(message)) = recv.recv(ctx).await {
+        let view_number = message.message.msg.view().number.0 as usize;
+        // Here we assume that all instances start from view 0 in the tests.
+        // If the view is higher than what we have planned for, assume no partitions.
+        // Every node is guaranteed to be present in only one partition.
+        let partitions_opt = splits.get(view_number);
+
+        let msg = || {
+            io::OutputMessage::Consensus(io::ConsensusReq {
+                msg: message.message.clone(),
+                ack: oneshot::channel().0,
+            })
+        };
+
+        match message.recipient {
+            io::Target::Broadcast => match partitions_opt {
+                None => {
+                    eprintln!("broadcasting view={view_number} from={port} target=all");
+                    for target_port in sends.keys() {
+                        send_or_stash(true, *target_port, msg());
+                    }
+                }
+                Some(ps) => {
+                    for p in ps {
+                        let can_send = p.contains(&port);
+                        eprintln!("broadcasting view={view_number} from={port} target={p:?} can_send={can_send} t={}", start.elapsed().as_seconds_f64());
+                        for target_port in p {
+                            send_or_stash(can_send, *target_port, msg());
+                        }
+                    }
+                }
+            },
+            io::Target::Validator(v) => {
+                let target_ports = &validator_ports[&v];
+
+                match partitions_opt {
+                    None => {
+                        for target_port in target_ports {
+                            eprintln!(
+                                "unicasting view={view_number} from={port} target={target_port}"
+                            );
+                            send_or_stash(true, *target_port, msg());
+                        }
+                    }
+                    Some(ps) => {
+                        for p in ps {
+                            let can_send = p.contains(&port);
+                            for target_port in target_ports {
+                                if p.contains(target_port) {
+                                    eprintln!("unicasting view={view_number} from={port} target={target_port } can_send={can_send} t={}", start.elapsed().as_seconds_f64());
+                                    send_or_stash(can_send, *target_port, msg());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn output_msg_view_number(msg: &io::OutputMessage) -> u64 {
@@ -363,6 +384,6 @@ fn output_msg_view_number(msg: &io::OutputMessage) -> u64 {
 
 fn output_msg_label(msg: &io::OutputMessage) -> &str {
     match msg {
-        io::OutputMessage::Consensus(cr) => cr.msg.msg.label()
+        io::OutputMessage::Consensus(cr) => cr.msg.msg.label(),
     }
 }

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -251,7 +251,7 @@ async fn run_nodes_twins(
                 .instrument(tracing::info_span!("node", i)),
             );
         }
-        // Taking these refeferences is necessary for the `scope::run!` environment lifetime rules to compile
+        // Taking these references is necessary for the `scope::run!` environment lifetime rules to compile
         // with `async move`, which in turn is necessary otherwise it the spawned process could not borrow `port`.
         // Potentially `ctx::NoCopy` could be used with `port`.
         let validator_ports = &validator_ports;
@@ -264,8 +264,8 @@ async fn run_nodes_twins(
         // * identify the view they are in from the message
         // * identify the partition they are in based on their network id
         // * either broadcast to all other instances in the partition, or find out the network
-        //   identity of the target validator and send to it _iff_ they are in the same partition
-        // * simulating the gossiping of finalized blockss
+        //   identity of the target validator and send to it iff they are in the same partition
+        // * simulate the gossiping of finalized blockss
         scope::run!(ctx, |ctx, s| async move {
             for (port, recv) in recvs {
                 let gossip_send = gossip_send.clone();
@@ -321,10 +321,7 @@ async fn twins_receive_loop(
 
     // We need to buffer messages that cannot be delivered due to partitioning, and deliver them later.
     // The spec says that the network is expected to deliver messages eventually, potentially out of order,
-    // caveated by the fact that the actual implementation only keep retrying the last message.
-    // However with the actors instantiated in by this test, that would not be sufficient because
-    // there is no gossip network here, and if a replica misses a proposal, it won't get it via gossip,
-    // and will forever be unable to finalize blocks.
+    // caveated by the fact that the actual implementation only keeps retrying the last message..
     // A separate issue is the definition of "later", without actually adding timing assumptions:
     // * If we want to allow partitions which don't have enough replicas for a quorum, and the replicas
     //   don't move on from a view until they reach quorum, then "later" could be defined by so many

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -309,7 +309,7 @@ async fn twins_receive_loop(
     mut recv: UnboundedReceiver<io::InputMessage>,
 ) -> anyhow::Result<()> {
     let rng = &mut ctx.rng();
-    let start = &ctx.now();
+    let start = std::time::Instant::now(); // Just to give an idea of how long time passes between rounds.
 
     // Finalized block number iff this node can gossip to the target and the message contains a QC.
     let block_to_gossip = |target_port: Port, msg: &io::OutputMessage| {
@@ -409,7 +409,7 @@ async fn twins_receive_loop(
                 Some(ps) => {
                     for p in ps {
                         let can_send = p.contains(&port);
-                        eprintln!("broadcasting view={view_number} from={port} target={p:?} can_send={can_send} t={}", start.elapsed().as_seconds_f64());
+                        eprintln!("broadcasting view={view_number} from={port} target={p:?} can_send={can_send} t={}", start.elapsed().as_secs());
                         for target_port in p {
                             send_or_stash(can_send, *target_port, msg());
                         }
@@ -433,7 +433,7 @@ async fn twins_receive_loop(
                             let can_send = p.contains(&port);
                             for target_port in target_ports {
                                 if p.contains(target_port) {
-                                    eprintln!("unicasting view={view_number} from={port} target={target_port } can_send={can_send} t={}", start.elapsed().as_seconds_f64());
+                                    eprintln!("unicasting view={view_number} from={port} target={target_port } can_send={can_send} t={}", start.elapsed().as_secs());
                                     send_or_stash(can_send, *target_port, msg());
                                 }
                             }

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -266,15 +266,15 @@ async fn run_nodes_twins(
                                 match partitions_opt {
                                     None => {
                                         for target_port in target_ports {
-                                            sends[&target_port].send(msg());
+                                            sends[target_port].send(msg());
                                         }
                                     }
                                     Some(ps) => {
                                         for p in ps {
                                             if p.contains(&port) {
                                                 for target_port in target_ports {
-                                                    if p.contains(&target_port) {
-                                                        sends[&target_port].send(msg())
+                                                    if p.contains(target_port) {
+                                                        sends[target_port].send(msg())
                                                     }
                                                 }
                                                 break;

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -246,7 +246,7 @@ async fn run_twins(
 ) -> anyhow::Result<()> {
     zksync_concurrency::testonly::abort_on_panic();
     // Use a single timeout for all scenarios to finish.
-    let _guard = zksync_concurrency::testonly::set_timeout(time::Duration::seconds(20));
+    let _guard = zksync_concurrency::testonly::set_timeout(time::Duration::seconds(30));
 
     #[derive(PartialEq)]
     struct Replica {

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -232,9 +232,9 @@ async fn twins_network_wo_twins_wo_partitions() {
 /// is resilient to temporary network partitions.
 #[tokio::test(flavor = "multi_thread")]
 async fn twins_network_wo_twins_w_partitions() {
-    let ctx = &ctx::test_root(&ctx::AffineClock::new(5.0));
-    // TODO: At the moment this test doesn't work with partitions, so just try to do a single scenario to debug.
-    run_twins(ctx, 6, false, 1).await.unwrap();
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
+    // n=6 implies f=1 and q=5; 6 is the minimum where partitions are possible.
+    run_twins(ctx, 6, false, 10).await.unwrap();
 }
 
 /// Create network configuration for a given number of replicas with a random number of twins and run [Test].

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -325,11 +325,6 @@ async fn run_twins(
     let cluster = Cluster::new(replicas, num_twins);
     let scenarios = ScenarioGenerator::new(&cluster, num_rounds, max_partitions);
 
-    eprintln!(
-        "num_replicas={num_replicas} num_twins={num_twins} num_nodes={}",
-        cluster.num_nodes()
-    );
-
     // Create network config for all nodes in the cluster (assigns unique network addresses).
     let nets = new_configs_for_validators(rng, cluster.nodes().iter().map(|r| &r.secret_key), 1);
 
@@ -346,7 +341,7 @@ async fn run_twins(
     let nodes = vec![(Behavior::Honest, WEIGHT); cluster.num_nodes()];
 
     // Reuse the same cluster and network setup to run a few scenarios.
-    for _ in 0..num_scenarios {
+    for i in 0..num_scenarios {
         // Generate a permutation of partitions and leaders for the given number of rounds.
         let scenario = scenarios.generate_one(rng);
 
@@ -368,6 +363,11 @@ async fn run_twins(
                     .collect()
             })
             .collect();
+
+        eprintln!(
+            "num_replicas={num_replicas} num_twins={num_twins} num_nodes={} scenario={i}",
+            cluster.num_nodes()
+        );
 
         for (r, rc) in scenario.rounds.iter().enumerate() {
             let leader_id = cluster

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -380,7 +380,7 @@ async fn run_twins(
 
             let leader_partition_sizes = leader_ports
                 .iter()
-                .map(|lp| partitions.iter().find(|p| p.contains(&lp)).unwrap().len())
+                .map(|lp| partitions.iter().find(|p| p.contains(lp)).unwrap().len())
                 .collect::<Vec<_>>();
 
             let leader_isolated = leader_partition_sizes

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -232,7 +232,7 @@ async fn twins_network_wo_twins_wo_partitions() {
 /// is resilient to temporary network partitions.
 #[tokio::test(flavor = "multi_thread")]
 async fn twins_network_wo_twins_w_partitions() {
-    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(5.0));
     // TODO: At the moment this test doesn't work with partitions, so just try to do a single scenario to debug.
     run_twins(ctx, 6, false, 1).await.unwrap();
 }

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -363,7 +363,7 @@ async fn run_twins(
             })
             .collect();
 
-        eprintln!(
+        tracing::info!(
             "num_replicas={num_replicas} num_twins={num_twins} num_nodes={} scenario={i}",
             cluster.num_nodes()
         );
@@ -387,7 +387,7 @@ async fn run_twins(
                 .iter()
                 .all(|s| *s < cluster.quorum_size());
 
-            eprintln!("round={r} partitions={partitions:?} leaders={leader_ports:?} leader_partition_sizes={leader_partition_sizes:?} leader_isolated={leader_isolated}");
+            tracing::debug!("round={r} partitions={partitions:?} leaders={leader_ports:?} leader_partition_sizes={leader_partition_sizes:?} leader_isolated={leader_isolated}");
         }
 
         Test {

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -245,7 +245,7 @@ async fn twins_network_w1_twins_w_partitions() {
         // let num_honest = validator::threshold(num_replicas as u64) as usize;
         // let max_faulty = num_replicas - num_honest;
         // let num_twins = rng.gen_range(1..=max_faulty);
-        run_twins(ctx, num_replicas, 1, 3).await.unwrap();
+        run_twins(ctx, num_replicas, 1, 5).await.unwrap();
     }
 }
 
@@ -254,8 +254,7 @@ async fn twins_network_w1_twins_w_partitions() {
 async fn twins_network_w2_twins_w_partitions() {
     let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
     // n>=11 implies f>=2 and q=n-f
-    // TODO: This fails for now.
-    run_twins(ctx, 11, 2, 1).await.unwrap();
+    run_twins(ctx, 11, 2, 5).await.unwrap();
 }
 
 /// Create network configuration for a given number of replicas and twins and run [Test].
@@ -268,7 +267,7 @@ async fn run_twins(
     zksync_concurrency::testonly::abort_on_panic();
     // Use a single timeout for all scenarios to finish.
     // A single scenario with 11 replicas took 3-5 seconds.
-    let _guard = zksync_concurrency::testonly::set_timeout(time::Duration::seconds(30));
+    let _guard = zksync_concurrency::testonly::set_timeout(time::Duration::seconds(60));
 
     #[derive(PartialEq, Debug)]
     struct Replica {

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -233,24 +233,28 @@ async fn twins_network_wo_twins_wo_partitions() {
 async fn twins_network_wo_twins_w_partitions() {
     let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
     // n=6 implies f=1 and q=5; 6 is the minimum where partitions are possible.
-    run_twins(ctx, 6, 0, 10).await.unwrap();
+    run_twins(ctx, 6, 0, 5).await.unwrap();
 }
 
-/// Run Twins scenarios with random number of nodes and twins.
+/// Run Twins scenarios with random number of nodes and 1 twin.
 #[tokio::test(flavor = "multi_thread")]
-async fn twins_network_w_twins_w_partitions() {
+async fn twins_network_w1_twins_w_partitions() {
     let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
     // n>=6 implies f>=1 and q=n-f
-    // for _ in 0..5 {
-    //     let rng = &mut ctx.rng();
-    //     let num_replicas = rng.gen_range(6..=11);
-    //     let num_honest = validator::threshold(num_replicas as u64) as usize;
-    //     let max_faulty = num_replicas - num_honest;
-    //     let num_twins = rng.gen_range(1..=max_faulty);
-    //     run_twins(ctx, num_replicas, num_twins, 1).await.unwrap();
-    // }
+    for num_replicas in 6..=10 {
+        // let num_honest = validator::threshold(num_replicas as u64) as usize;
+        // let max_faulty = num_replicas - num_honest;
+        // let num_twins = rng.gen_range(1..=max_faulty);
+        run_twins(ctx, num_replicas, 1, 3).await.unwrap();
+    }
+}
 
-    // Try the maximum
+/// Run Twins scenarios with higher number of nodes and 2 twins.
+#[tokio::test(flavor = "multi_thread")]
+async fn twins_network_w2_twins_w_partitions() {
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
+    // n>=11 implies f>=2 and q=n-f
+    // TODO: This fails for now.
     run_twins(ctx, 11, 2, 1).await.unwrap();
 }
 
@@ -299,7 +303,7 @@ async fn run_twins(
     // where the leader might not be in a partition with enough replicas to
     // form a quorum, therefore to allow N blocks to be finalized we need to
     // go longer.
-    let num_rounds = blocks_to_finalize * 5;
+    let num_rounds = blocks_to_finalize * 10;
     // The paper considers 2 or 3 partitions enough.
     let max_partitions = 3;
 

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -213,6 +213,7 @@ async fn non_proposing_leader() {
 /// to see that the basic mechanics of the network allow finalizations to happen.
 #[tokio::test(flavor = "multi_thread")]
 async fn honest_no_twins_network() {
+    // TODO: Speed up the clock.
     let ctx = &ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
 
@@ -262,7 +263,7 @@ async fn run_twins(ctx: &Ctx, num_replicas: usize, use_twins: bool) {
 
     // Everyone on the twins network is honest.
     // For now assign one power each (not, say, 100 each, or varying weights).
-    let mut nodes = vec![(Behavior::Honest, 1u64); num_replicas];
+    let nodes = vec![(Behavior::Honest, 1u64); num_replicas];
     let num_honest = validator::threshold(num_replicas as u64) as usize;
     let num_faulty = num_replicas - num_honest;
     let num_twins = if use_twins && num_faulty > 0 {
@@ -304,6 +305,7 @@ async fn run_twins(ctx: &Ctx, num_replicas: usize, use_twins: bool) {
             .iter()
             .chain(setup.validator_keys.iter().take(num_twins));
 
+        // Create the network configuration, e.g. assign a unique network address to each validator.
         let nets = new_configs_for_validators(rng, validator_keys, 1);
 
         // TODO: Create a network mode that supports partition schedule,

--- a/node/actors/network/src/gossip/fetch.rs
+++ b/node/actors/network/src/gossip/fetch.rs
@@ -64,7 +64,7 @@ impl Queue {
     ) -> ctx::OrCanceled<Call> {
         let sub = &mut self.0.subscribe();
         while ctx.is_active() {
-            // Wait for the lowest requested block to be available.
+            // Wait for the lowest requested block to be available on the remote peer.
             // This scope is always cancelled, so we ignore the result.
             let mut block_number = None;
             let _: Result<(), _> = scope::run!(ctx, |ctx, s| async {

--- a/node/actors/network/src/gossip/mod.rs
+++ b/node/actors/network/src/gossip/mod.rs
@@ -49,6 +49,8 @@ pub(crate) struct Network {
     /// Output pipe of the network actor.
     pub(crate) sender: channel::UnboundedSender<io::OutputMessage>,
     /// Queue of block fetching requests.
+    ///
+    /// These are blocks that this node wants to request from remote peers via RPC.
     pub(crate) fetch_queue: fetch::Queue,
     /// Last viewed QC.
     pub(crate) last_viewed_qc: Option<attester::BatchQC>,

--- a/node/actors/network/src/gossip/runner.rs
+++ b/node/actors/network/src/gossip/runner.rs
@@ -204,6 +204,7 @@ impl Network {
 
             // Perform get_block calls to peer.
             s.spawn::<()>(async {
+                // Gossiped state of what range of blocks is available on the remote peer.
                 let state = &mut push_block_store_state_server.state.subscribe();
                 loop {
                     let call = get_block_client.reserve(ctx).await?;

--- a/node/actors/network/src/testonly.rs
+++ b/node/actors/network/src/testonly.rs
@@ -13,10 +13,7 @@ use std::{
     sync::Arc,
 };
 use zksync_concurrency::{ctx, ctx::channel, io, limiter, net, scope, sync};
-use zksync_consensus_roles::{
-    node,
-    validator::{self, SecretKey},
-};
+use zksync_consensus_roles::{node, validator};
 use zksync_consensus_storage::BlockStore;
 use zksync_consensus_utils::pipe;
 
@@ -92,7 +89,7 @@ pub fn new_configs_for_validators<'a, I>(
     gossip_peers: usize,
 ) -> Vec<Config>
 where
-    I: Iterator<Item = &'a SecretKey>,
+    I: Iterator<Item = &'a validator::SecretKey>,
 {
     let configs = validator_keys.map(|validator_key| {
         let addr = net::tcp::testonly::reserve_listener();

--- a/node/libs/utils/src/pipe.rs
+++ b/node/libs/utils/src/pipe.rs
@@ -5,12 +5,30 @@ use std::future::Future;
 use zksync_concurrency::ctx::{self, channel, Ctx};
 
 /// This is the end of the Pipe that should be held by the actor.
+///
+/// The actor can receive `In` and send back `Out` messages.
 pub type ActorPipe<In, Out> = Pipe<In, Out>;
 
 /// This is the end of the Pipe that should be held by the dispatcher.
+///
+/// The dispatcher can send `In` messages and receive `Out` back.
 pub type DispatcherPipe<In, Out> = Pipe<Out, In>;
 
 /// This is a generic Pipe end.
+///
+/// It is used to receive `In` and send `Out` messages.
+///
+/// When viewed from the perspective of [new]:
+/// * messages of type `In` are going right-to-left
+/// * messages of type `Out` are going left-to-right
+///
+/// ```text
+///  In  <- -------- <- In
+///         | Pipe |
+///  Out -> -------- -> Out
+///  ^                  ^
+///  Actor              Dispatcher
+/// ```
 #[derive(Debug)]
 pub struct Pipe<In, Out> {
     /// This is the channel that receives messages.


### PR DESCRIPTION
## What ❔

Add tests that run multiple Twins scenarios with random number of replicas as twins.

- [x] Add `Network::Twins` type with a partition schedule
- [x] Add `run_nodes_twins` to execute the test with arbitrary network partitions and potentially multiple ports per validator
- [x] Buffer messages that can't be delivered and deliver them sometime later (potentially unless superseded by a newer message from source to target)
- [x] Simulate the gossiping of finalized blocks
- [x] Run test with no twins and no partitions
- [x] Run test with no twins but random partitions 
- [x] Run test with twins and random partitions 
### Investigation

```shell
cargo nextest run -p zksync_consensus_bft twins_network --no-capture
```

Initially the test failed when partitions are introduced. I'll try to understand if this is because the leader got isolated and an important message got lost. Would like to understand if eventual delivery is an absolute requirement even if all partitions are at least as large as the quorum size.

🔍  I think the reason for the test failing is because it looks for all nodes having persisted a certain number of blocks, but if a proposal with the payload is missed due to a partition preventing the message from being delivered, then there is no mechanism in the machinery instantiated by the test to procure these later, and those nodes are stuck.

🔧 I implemented a message stashing mechanism in the mock network but it still doesn't finalise blocks 👀 

🔍 The problem seems to be that my unstashing mechanism only kicked in when node A tried to send a new message to node B and wasn't blocked any more. However if A didn't try to send, then the stashed messages to B weren't delivered, which causes longer and longer timeouts as nobody is making progress for one reason or another. Meanwhile for example C can be already in a new view, so if we see that, we could conclude that A-to-B should be unstashed as well even if there are no messages from A to B in that round. 

🔧 I'll try testing after merging https://github.com/matter-labs/era-consensus/pull/119 which should trigger unstashes in each round.

🔍 It's still failing after adding the replica-to-replica broadcast. For example one replica A is isolated in a round 1 and doesn't get a LeaderCommit; then in the next round replica B is isolated, and A gets all the missing messages from round 1, plus the new LeaderPrepare, but it doesn't respond with a ReplicaCommit because it doesn't have the block from round 1, and therefore cannot even store proposal 2. The consensus relies on the external gossiping mechanism to eventually propagate the FinalBlock to it; until then the node is stuck. I need to simulate the effect of gossiping in the test.

🔧 I implemented a simulated gossip using the following mechanism: if one node is about to send/unstash a message to another and they are in a gossip relationship, and the message contains a CommitQC, and the sender has the finalized block for the committed height, then it inserts the block directly into the target store.

🔍 The tests now work without twins, but fail with 1 or 2 twins, albeit not on every scenario

🔧 Changed the simulated gossip to push all ancestors of a finalized block into the target blockstore, not just the one in the CommitQC that is in the latest message. This simulates the ability of the target to fetch all missing blocks.

## Why ❔

To check that the consensus does not fail as long as the number of twins does not exceed the tolerable number of Byzantine nodes.