### PR TITLE
Make validators broadcast the high Commit QC (BFT-458)

### DIFF
--- a/node/actors/bft/src/leader/replica_commit.rs
+++ b/node/actors/bft/src/leader/replica_commit.rs
@@ -1,9 +1,8 @@
 //! Handler of a ReplicaCommit message.
 
-use std::collections::HashSet;
-
 use super::StateMachine;
 use crate::metrics;
+use std::collections::HashSet;
 use tracing::instrument;
 use zksync_concurrency::{ctx, metrics::LatencyHistogramExt as _};
 use zksync_consensus_network::io::{ConsensusInputMessage, Target};

--- a/node/actors/bft/src/leader/replica_prepare.rs
+++ b/node/actors/bft/src/leader/replica_prepare.rs
@@ -1,7 +1,6 @@
 //! Handler of a ReplicaPrepare message.
-use std::collections::HashSet;
-
 use super::StateMachine;
+use std::collections::HashSet;
 use tracing::instrument;
 use zksync_concurrency::{ctx, error::Wrap};
 use zksync_consensus_roles::validator;

--- a/node/actors/bft/src/replica/block.rs
+++ b/node/actors/bft/src/replica/block.rs
@@ -6,6 +6,8 @@ impl StateMachine {
     /// Tries to build a finalized block from the given CommitQC. We simply search our
     /// block proposal cache for the matching block, and if we find it we build the block.
     /// If this method succeeds, it sends the finalized block to the executor.
+    /// It also updates the High QC in the replica state machine, if the received QC is
+    /// higher.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn save_block(
         &mut self,

--- a/node/actors/bft/src/replica/mod.rs
+++ b/node/actors/bft/src/replica/mod.rs
@@ -5,6 +5,7 @@
 mod block;
 pub(crate) mod leader_commit;
 pub(crate) mod leader_prepare;
+pub(crate) mod replica_prepare;
 mod new_view;
 mod state_machine;
 #[cfg(test)]

--- a/node/actors/bft/src/replica/mod.rs
+++ b/node/actors/bft/src/replica/mod.rs
@@ -5,8 +5,8 @@
 mod block;
 pub(crate) mod leader_commit;
 pub(crate) mod leader_prepare;
-pub(crate) mod replica_prepare;
 mod new_view;
+pub(crate) mod replica_prepare;
 mod state_machine;
 #[cfg(test)]
 mod tests;

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -24,7 +24,7 @@ impl StateMachine {
         // Backup our state.
         self.backup_state(ctx).await.wrap("backup_state()")?;
 
-        // Send the replica message to the next leader.
+        // Send the replica message.
         let output_message = ConsensusInputMessage {
             message: self
                 .config

--- a/node/actors/bft/src/replica/new_view.rs
+++ b/node/actors/bft/src/replica/new_view.rs
@@ -39,7 +39,7 @@ impl StateMachine {
                         high_qc: self.high_qc.clone(),
                     },
                 )),
-            recipient: Target::Validator(self.config.genesis().view_leader(self.view)),
+            recipient: Target::Broadcast,
         };
         self.outbound_pipe.send(output_message.into());
 

--- a/node/actors/bft/src/replica/replica_prepare.rs
+++ b/node/actors/bft/src/replica/replica_prepare.rs
@@ -78,11 +78,8 @@ impl StateMachine {
         signed_message.verify().map_err(Error::InvalidSignature)?;
 
         // Extract the QC and verify it.
-        let high_qc = match message.high_qc {
-            Some(qc) => qc,
-            None => {
-                return Ok(());
-            }
+        let Some(high_qc) = message.high_qc else {
+            return Ok(());
         };
 
         high_qc.verify(self.config.genesis()).map_err(|err| {

--- a/node/actors/bft/src/replica/replica_prepare.rs
+++ b/node/actors/bft/src/replica/replica_prepare.rs
@@ -1,0 +1,103 @@
+//! Handler of a ReplicaPrepare message.
+use super::StateMachine;
+use tracing::instrument;
+use zksync_concurrency::{ctx, error::Wrap};
+use zksync_consensus_roles::validator;
+
+/// Errors that can occur when processing a "replica prepare" message.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    /// Message signer isn't part of the validator set.
+    #[error("Message signer isn't part of the validator set (signer: {signer:?})")]
+    NonValidatorSigner {
+        /// Signer of the message.
+        signer: validator::PublicKey,
+    },
+    /// Past view or phase.
+    #[error("past view/phase (current view: {current_view:?}, current phase: {current_phase:?})")]
+    Old {
+        /// Current view.
+        current_view: validator::ViewNumber,
+        /// Current phase.
+        current_phase: validator::Phase,
+    },
+    /// Invalid message signature.
+    #[error("invalid signature: {0:#}")]
+    InvalidSignature(#[source] anyhow::Error),
+    /// Invalid message.
+    #[error(transparent)]
+    InvalidMessage(validator::ReplicaPrepareVerifyError),
+    /// Internal error. Unlike other error types, this one isn't supposed to be easily recoverable.
+    #[error(transparent)]
+    Internal(#[from] ctx::Error),
+}
+
+impl Wrap for Error {
+    fn with_wrap<C: std::fmt::Display + Send + Sync + 'static, F: FnOnce() -> C>(
+        self,
+        f: F,
+    ) -> Self {
+        match self {
+            Error::Internal(err) => Error::Internal(err.with_wrap(f)),
+            err => err,
+        }
+    }
+}
+
+impl StateMachine {
+    #[instrument(level = "trace", skip(self), ret)]
+    pub(crate) async fn process_replica_prepare(
+        &mut self,
+        ctx: &ctx::Ctx,
+        signed_message: validator::Signed<validator::ReplicaPrepare>,
+    ) -> Result<(), Error> {
+        // ----------- Checking origin of the message --------------
+
+        // Unwrap message.
+        let message = signed_message.msg.clone();
+        let author = &signed_message.key;
+
+        // Check that the message signer is in the validator set.
+        if !self.config.genesis().validators.contains(author) {
+            return Err(Error::NonValidatorSigner {
+                signer: author.clone(),
+            });
+        }
+
+        // If the message is from the "past", we discard it.
+        // That is, it's from a previous view or phase.
+        if (message.view.number, validator::Phase::Prepare) < (self.view, self.phase) {
+            return Err(Error::Old {
+                current_view: self.view,
+                current_phase: self.phase,
+            });
+        }
+
+        // ----------- Checking the signed part of the message --------------
+
+        // Check the signature on the message.
+        signed_message.verify().map_err(Error::InvalidSignature)?;
+
+        // Verify the message.
+        message
+            .verify(self.config.genesis())
+            .map_err(Error::InvalidMessage)?;
+
+        // ----------- All checks finished. Now we process the message. --------------
+
+        // Update our high QC, if necessary.
+        if message.high_qc.clone().map(|x| x.view().number)
+            > self.high_qc.clone().map(|x| x.view().number)
+        {
+            self.high_qc = message.high_qc;
+        }
+
+        // Skip to a new view, if necessary.
+        // if message.view.number > self.view {
+        //     self.view = message.view.number;
+        //     self.start_new_view(ctx).await.wrap("start_new_view()")?;
+        // }
+
+        Ok(())
+    }
+}

--- a/node/actors/bft/src/replica/replica_prepare.rs
+++ b/node/actors/bft/src/replica/replica_prepare.rs
@@ -91,12 +91,8 @@ impl StateMachine {
         let qc_view = high_qc.view().number;
 
         // Try to create a finalized block with this CommitQC and our block proposal cache.
+        // It will also update our high QC, if necessary.
         self.save_block(ctx, &high_qc).await.wrap("save_block()")?;
-
-        // Update our high QC, if necessary.
-        if Some(qc_view) > self.high_qc.clone().map(|x| x.view().number) {
-            self.high_qc = Some(high_qc);
-        }
 
         // Skip to a new view, if necessary.
         if qc_view >= self.view {

--- a/node/actors/bft/src/replica/state_machine.rs
+++ b/node/actors/bft/src/replica/state_machine.rs
@@ -113,11 +113,18 @@ impl StateMachine {
                         .wrap("process_replica_prepare()")
                     {
                         Ok(()) => Ok(()),
-                        Err(super::replica_prepare::Error::Internal(err)) => {
-                            return Err(err);
-                        }
                         Err(err) => {
-                            tracing::warn!("process_replica_prepare: {err:#}");
+                            match err {
+                                super::replica_prepare::Error::Internal(e) => {
+                                    return Err(e);
+                                }
+                                super::replica_prepare::Error::Old { .. } => {
+                                    tracing::info!("process_replica_prepare: {err:#}");
+                                }
+                                _ => {
+                                    tracing::warn!("process_replica_prepare: {err:#}");
+                                }
+                            }
                             Err(())
                         }
                     };
@@ -129,12 +136,21 @@ impl StateMachine {
                         .await
                         .wrap("process_leader_prepare()")
                     {
-                        Err(super::leader_prepare::Error::Internal(err)) => return Err(err),
+                        Ok(()) => Ok(()),
                         Err(err) => {
-                            tracing::warn!("process_leader_prepare(): {err:#}");
+                            match err {
+                                super::leader_prepare::Error::Internal(e) => {
+                                    return Err(e);
+                                }
+                                super::leader_prepare::Error::Old { .. } => {
+                                    tracing::info!("process_leader_prepare: {err:#}");
+                                }
+                                _ => {
+                                    tracing::warn!("process_leader_prepare: {err:#}");
+                                }
+                            }
                             Err(())
                         }
-                        Ok(()) => Ok(()),
                     };
                     metrics::ConsensusMsgLabel::LeaderPrepare.with_result(&res)
                 }
@@ -144,12 +160,21 @@ impl StateMachine {
                         .await
                         .wrap("process_leader_commit()")
                     {
-                        Err(super::leader_commit::Error::Internal(err)) => return Err(err),
+                        Ok(()) => Ok(()),
                         Err(err) => {
-                            tracing::warn!("process_leader_commit(): {err:#}");
+                            match err {
+                                super::leader_commit::Error::Internal(e) => {
+                                    return Err(e);
+                                }
+                                super::leader_commit::Error::Old { .. } => {
+                                    tracing::info!("process_leader_commit: {err:#}");
+                                }
+                                _ => {
+                                    tracing::warn!("process_leader_commit: {err:#}");
+                                }
+                            }
                             Err(())
                         }
-                        Ok(()) => Ok(()),
                     };
                     metrics::ConsensusMsgLabel::LeaderCommit.with_result(&res)
                 }

--- a/node/actors/network/src/gossip/mod.rs
+++ b/node/actors/network/src/gossip/mod.rs
@@ -12,6 +12,7 @@
 //! Static connections constitute a rigid "backbone" of the gossip network, which is insensitive to
 //! eclipse attack. Dynamic connections are supposed to improve the properties of the gossip
 //! network graph (minimize its diameter, increase connectedness).
+use self::batch_votes::BatchVotesWatch;
 use crate::{gossip::ValidatorAddrsWatch, io, pool::PoolWatch, Config};
 use anyhow::Context as _;
 use im::HashMap;
@@ -20,8 +21,6 @@ pub(crate) use validator_addrs::*;
 use zksync_concurrency::{ctx, ctx::channel, scope, sync};
 use zksync_consensus_roles::{attester, node, validator};
 use zksync_consensus_storage::BlockStore;
-
-use self::batch_votes::BatchVotesWatch;
 
 mod batch_votes;
 mod fetch;

--- a/node/actors/network/src/rpc/push_batch_votes.rs
+++ b/node/actors/network/src/rpc/push_batch_votes.rs
@@ -1,8 +1,7 @@
 //! Defines RPC for passing consensus messages.
-use std::sync::Arc;
-
 use crate::{mux, proto::gossip as proto};
 use anyhow::Context as _;
+use std::sync::Arc;
 use zksync_consensus_roles::attester::{self, Batch};
 use zksync_protobuf::ProtoFmt;
 

--- a/node/libs/roles/src/attester/conv.rs
+++ b/node/libs/roles/src/attester/conv.rs
@@ -1,13 +1,12 @@
+use super::{
+    AggregateSignature, Batch, BatchNumber, BatchQC, Msg, MsgHash, PublicKey, Signature, Signed,
+    Signers, WeightedAttester,
+};
 use crate::proto::attester::{self as proto};
 use anyhow::Context as _;
 use zksync_consensus_crypto::ByteFmt;
 use zksync_consensus_utils::enum_util::Variant;
 use zksync_protobuf::{read_required, required, ProtoFmt};
-
-use super::{
-    AggregateSignature, Batch, BatchNumber, BatchQC, Msg, MsgHash, PublicKey, Signature, Signed,
-    Signers, WeightedAttester,
-};
 
 impl ProtoFmt for Batch {
     type Proto = proto::Batch;

--- a/node/libs/roles/src/attester/keys/aggregate_signature.rs
+++ b/node/libs/roles/src/attester/keys/aggregate_signature.rs
@@ -1,6 +1,5 @@
-use crate::attester::{Batch, MsgHash};
-
 use super::{PublicKey, Signature};
+use crate::attester::{Batch, MsgHash};
 use std::fmt;
 use zksync_consensus_crypto::{bn254, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::Variant;

--- a/node/libs/roles/src/attester/keys/signature.rs
+++ b/node/libs/roles/src/attester/keys/signature.rs
@@ -1,6 +1,5 @@
-use crate::attester::{Msg, MsgHash};
-
 use super::PublicKey;
+use crate::attester::{Msg, MsgHash};
 use std::fmt;
 use zksync_consensus_crypto::{bn254, ByteFmt, Text, TextFmt};
 

--- a/node/libs/roles/src/attester/messages/batch.rs
+++ b/node/libs/roles/src/attester/messages/batch.rs
@@ -1,6 +1,5 @@
-use crate::{attester, validator::Genesis};
-
 use super::{Signed, Signers};
+use crate::{attester, validator::Genesis};
 use anyhow::{ensure, Context as _};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd)]

--- a/node/libs/roles/src/attester/messages/msg.rs
+++ b/node/libs/roles/src/attester/messages/msg.rs
@@ -1,8 +1,7 @@
-use std::{collections::BTreeMap, fmt};
-
 use crate::{attester, validator};
 use anyhow::Context as _;
 use bit_vec::BitVec;
+use std::{collections::BTreeMap, fmt};
 use zksync_consensus_crypto::{keccak256, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::{BadVariantError, Variant};
 

--- a/node/libs/roles/src/attester/mod.rs
+++ b/node/libs/roles/src/attester/mod.rs
@@ -8,5 +8,4 @@ mod keys;
 mod messages;
 mod testonly;
 
-pub use self::keys::*;
-pub use self::messages::*;
+pub use self::{keys::*, messages::*};

--- a/node/libs/roles/src/attester/tests.rs
+++ b/node/libs/roles/src/attester/tests.rs
@@ -1,6 +1,5 @@
-use crate::validator::testonly::Setup;
-
 use super::*;
+use crate::validator::testonly::Setup;
 use assert_matches::assert_matches;
 use rand::Rng;
 use zksync_concurrency::ctx;

--- a/node/libs/roles/src/validator/conv.rs
+++ b/node/libs/roles/src/validator/conv.rs
@@ -1,15 +1,15 @@
-use crate::{
-    attester::{self, WeightedAttester},
-    node::SessionId,
-};
-
 use super::{
     AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg,
     FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg,
     MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProtocolVersion, PublicKey,
     ReplicaCommit, ReplicaPrepare, Signature, Signed, Signers, View, ViewNumber, WeightedValidator,
 };
-use crate::{proto::validator as proto, validator::LeaderSelectionMode};
+use crate::{
+    attester::{self, WeightedAttester},
+    node::SessionId,
+    proto::validator as proto,
+    validator::LeaderSelectionMode,
+};
 use anyhow::Context as _;
 use std::collections::BTreeMap;
 use zksync_consensus_crypto::ByteFmt;

--- a/node/libs/roles/src/validator/messages/tests.rs
+++ b/node/libs/roles/src/validator/messages/tests.rs
@@ -1,5 +1,7 @@
-use crate::attester::{self, WeightedAttester};
-use crate::validator::*;
+use crate::{
+    attester::{self, WeightedAttester},
+    validator::*,
+};
 use anyhow::Context as _;
 use rand::{prelude::StdRng, Rng, SeedableRng};
 use zksync_concurrency::ctx;

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -1,6 +1,4 @@
 //! Test-only utilities.
-use crate::attester;
-
 use super::{
     AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg,
     FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg,
@@ -8,7 +6,7 @@ use super::{
     ReplicaCommit, ReplicaPrepare, SecretKey, Signature, Signed, Signers, View, ViewNumber,
     WeightedValidator,
 };
-use crate::validator::LeaderSelectionMode;
+use crate::{attester, validator::LeaderSelectionMode};
 use bit_vec::BitVec;
 use rand::{
     distributions::{Distribution, Standard},


### PR DESCRIPTION
## What ❔
We now broadcast the Replica Prepare message to all replicas. Replicas then use it to update their high Commit QCs and change views id necessary.

## Why ❔
The high Commit QC broadcast should be independent from the rest of the algorithm, so that view synchronization is independent from the bft logic - it simplifies reasoning a lot and prevents potential deadlocks that our implementation currently has