### PR TITLE
Fix ambiguous reproposal bug (BFT-454)

### DIFF
--- a/node/libs/roles/src/validator/messages/leader_prepare.rs
+++ b/node/libs/roles/src/validator/messages/leader_prepare.rs
@@ -90,10 +90,10 @@ impl PrepareQC {
         let mut high_votes: Vec<_> = count.into_iter().filter(|x| x.1 >= min).collect();
 
         if high_votes.len() == 1 {
-            return high_votes.pop().map(|x| x.0);
+            high_votes.pop().map(|x| x.0)
         } else {
-            return None;
-        };
+            None
+        }
     }
 
     /// Get the highest CommitQC.


### PR DESCRIPTION
## What ❔
Now if there are >1 subquorums in the PrepareQC, leader will create a new proposal and replicas will require a new proposal.

## Why ❔
It is possible to have 2 subquorums: vote A and vote B, each with >2f weight, in a single PrepareQC (even in the unweighted case, because QC contains n-f signatures, not 4f+1). In such a situation from the POV of the BFT algorithm, leader is eligible to do any of the following:

- reproposal for A
- reproposal for B
- a new proposal

Since the choice here is ambiguous, this can break liveness.
