### PR TITLE
Added PayloadVersion to the genesis.

### DIFF
--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -15,6 +15,7 @@ message Genesis {
   // These properties are expected to be overwritten each epoch.
   // We will either remove them entirely, or keep them for the initial epoch.
   optional uint32 protocol_version = 8; // required; ProtocolVersion
+  optional uint64 payload_version = 10; // optional; PayloadVersion
   repeated WeightedValidator validators_v1 = 3;
   repeated attester.WeightedAttester attesters = 9; // optional
   optional LeaderSelectionMode leader_selection = 4; // required

--- a/node/libs/roles/src/validator/conv.rs
+++ b/node/libs/roles/src/validator/conv.rs
@@ -1,9 +1,4 @@
-use super::{
-    AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg,
-    FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg,
-    MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProtocolVersion, PublicKey,
-    ReplicaCommit, ReplicaPrepare, Signature, Signed, Signers, View, ViewNumber, WeightedValidator,
-};
+use super::*;
 use crate::{
     attester::{self, WeightedAttester},
     node::SessionId,
@@ -39,6 +34,7 @@ impl ProtoFmt for GenesisRaw {
             first_block: BlockNumber(*required(&r.first_block).context("first_block")?),
 
             protocol_version: ProtocolVersion(r.protocol_version.context("protocol_version")?),
+            payload_version: r.payload_version.map(PayloadVersion),
             validators: Committee::new(validators.into_iter()).context("validators_v1")?,
             attesters: if attesters.is_empty() {
                 None
@@ -55,6 +51,7 @@ impl ProtoFmt for GenesisRaw {
             first_block: Some(self.first_block.0),
 
             protocol_version: Some(self.protocol_version.0),
+            payload_version: self.payload_version.map(|x| x.0),
             validators_v1: self.validators.iter().map(|v| v.build()).collect(),
             attesters: self
                 .attesters

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -42,6 +42,11 @@ impl TryFrom<u32> for ProtocolVersion {
     }
 }
 
+/// Version of the encoding scheme used to encode the block payloads.
+/// Semantics of this field is chain-dependent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PayloadVersion(pub u64);
+
 /// Number of the fork. Newer fork has higher number.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForkNumber(pub u64);
@@ -248,6 +253,9 @@ pub struct GenesisRaw {
     pub fork_number: ForkNumber,
     /// Protocol version used by this fork.
     pub protocol_version: ProtocolVersion,
+    /// Payload version used by this fork.
+    /// It determines what encoding scheme should the leader use to propose new blocks.
+    pub payload_version: Option<PayloadVersion>,
     /// First block of a fork.
     pub first_block: BlockNumber,
     /// Set of validators of the chain.


### PR DESCRIPTION
It will allow us to upgrade the payload encoding in zksync-era.
This is just one solution, alternatives are:
1. allow to actually include custom data in consensus Genesis, not just a version number.
2. same as 1, except we include just a hash of the custom data.
3. bump the zksync-era protocol version instead. That might be even preferrable, however I don't know whether we can afford bumping protocol version just for that.