### PR TITLE
BFT-466: LeaderPrepare wait for previous block deadlock

### DIFF
--- a/node/actors/bft/src/leader/state_machine.rs
+++ b/node/actors/bft/src/leader/state_machine.rs
@@ -94,11 +94,16 @@ impl StateMachine {
                         Err(err) => {
                             match err {
                                 super::replica_prepare::Error::Internal(e) => {
+                                    tracing::error!(
+                                        "process_replica_prepare: internal error: {e:#}"
+                                    );
+
                                     return Err(e);
                                 }
                                 super::replica_prepare::Error::Old { .. }
                                 | super::replica_prepare::Error::NotLeaderInView => {
-                                    tracing::info!("process_replica_prepare: {err:#}");
+                                    // It's broadcasted now, so everyone gets it.
+                                    tracing::debug!("process_replica_prepare: {err:#}");
                                 }
                                 _ => {
                                     tracing::warn!("process_replica_prepare: {err:#}");

--- a/node/actors/bft/src/replica/state_machine.rs
+++ b/node/actors/bft/src/replica/state_machine.rs
@@ -116,10 +116,13 @@ impl StateMachine {
                         Err(err) => {
                             match err {
                                 super::replica_prepare::Error::Internal(e) => {
+                                    tracing::error!(
+                                        "process_replica_prepare: internal error: {e:#}"
+                                    );
                                     return Err(e);
                                 }
                                 super::replica_prepare::Error::Old { .. } => {
-                                    tracing::info!("process_replica_prepare: {err:#}");
+                                    tracing::debug!("process_replica_prepare: {err:#}");
                                 }
                                 _ => {
                                     tracing::warn!("process_replica_prepare: {err:#}");
@@ -140,6 +143,9 @@ impl StateMachine {
                         Err(err) => {
                             match err {
                                 super::leader_prepare::Error::Internal(e) => {
+                                    tracing::error!(
+                                        "process_leader_prepare: internal error: {e:#}"
+                                    );
                                     return Err(e);
                                 }
                                 super::leader_prepare::Error::Old { .. } => {
@@ -164,6 +170,7 @@ impl StateMachine {
                         Err(err) => {
                             match err {
                                 super::leader_commit::Error::Internal(e) => {
+                                    tracing::error!("process_leader_commit: internal error: {e:#}");
                                     return Err(e);
                                 }
                                 super::leader_commit::Error::Old { .. } => {

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -23,7 +23,7 @@ use zksync_consensus_utils::pipe;
 pub(crate) enum Network {
     Real,
     Mock,
-    Twins(PortSplitSchedule),
+    Twins(PortRouter),
 }
 
 /// Number of phases within a view for which we consider different partitions.
@@ -46,6 +46,38 @@ pub(crate) type PortPartition = HashSet<Port>;
 pub(crate) type PortSplit = Vec<PortPartition>;
 /// A schedule contains a list of splits (one for each phase) for every view.
 pub(crate) type PortSplitSchedule = Vec<[PortSplit; NUM_PHASES]>;
+
+/// A predicate to gover who can communicate to whom a given message.
+#[derive(Clone)]
+pub(crate) enum PortRouter {
+    Splits(PortSplitSchedule),
+}
+
+impl PortRouter {
+    /// Decide whether a message can be sent from a sender to a target in the given view/phase.
+    ///
+    /// Returning `None` means the there was no more routing data and the test can decide to
+    /// allow all communication or to abort a runaway test.
+    fn can_send(&self, msg: &io::ConsensusInputMessage, from: Port, to: Port) -> Option<bool> {
+        match self {
+            PortRouter::Splits(splits) => {
+                // Here we assume that all instances start from view 0 in the tests.
+                // If the view is higher than what we have planned for, assume no partitions.
+                // Every node is guaranteed to be present in only one partition.
+                let view_number = input_msg_view_number(msg);
+                let phase_number = input_msg_phase_number(msg);
+                splits
+                    .get(view_number)
+                    .and_then(|ps| ps.get(phase_number))
+                    .map(|partitions| {
+                        partitions
+                            .iter()
+                            .any(|p| p.contains(&from) && p.contains(&to))
+                    })
+            }
+        }
+    }
+}
 
 /// Config for the test. Determines the parameters to run the test with.
 #[derive(Clone)]
@@ -124,7 +156,7 @@ async fn run_nodes(ctx: &ctx::Ctx, network: &Network, specs: &[Node]) -> anyhow:
     match network {
         Network::Real => run_nodes_real(ctx, specs).await,
         Network::Mock => run_nodes_mock(ctx, specs).await,
-        Network::Twins(splits) => run_nodes_twins(ctx, specs, splits).await,
+        Network::Twins(router) => run_nodes_twins(ctx, specs, router).await,
     }
 }
 
@@ -210,7 +242,7 @@ async fn run_nodes_mock(ctx: &ctx::Ctx, specs: &[Node]) -> anyhow::Result<()> {
 async fn run_nodes_twins(
     ctx: &ctx::Ctx,
     specs: &[Node],
-    splits: &PortSplitSchedule,
+    router: &PortRouter,
 ) -> anyhow::Result<()> {
     scope::run!(ctx, |ctx, s| async {
         // All known network ports of a validator, so that we can tell if any of
@@ -282,7 +314,7 @@ async fn run_nodes_twins(
                 s.spawn(async move {
                     twins_receive_loop(
                         ctx,
-                        splits,
+                        router,
                         validator_ports,
                         sends,
                         TwinsGossipConfig {
@@ -312,7 +344,7 @@ async fn run_nodes_twins(
 /// and won't be able to finalize the block, and won't participate further in the consensus.
 async fn twins_receive_loop(
     ctx: &ctx::Ctx,
-    splits: &PortSplitSchedule,
+    router: &PortRouter,
     validator_ports: &HashMap<validator::PublicKey, Vec<Port>>,
     sends: &HashMap<Port, UnboundedSender<io::OutputMessage>>,
     gossip: TwinsGossipConfig<'_>,
@@ -396,19 +428,8 @@ async fn twins_receive_loop(
     };
 
     while let Ok(io::InputMessage::Consensus(message)) = recv.recv(ctx).await {
-        let view_number = message.message.msg.view().number.0 as usize;
-        let phase_number = input_msg_phase_number(&message);
+        let view_number = input_msg_view_number(&message);
         let kind = message.message.msg.label();
-        // Here we assume that all instances start from view 0 in the tests.
-        // If the view is higher than what we have planned for, assume no partitions.
-        // Every node is guaranteed to be present in only one partition.
-        let partitions_opt = splits.get(view_number).and_then(|ps| ps.get(phase_number));
-
-        if partitions_opt.is_none() {
-            bail!(
-                "ran out of scheduled rounds; most likely cannot finalize blocks even if we go on"
-            );
-        }
 
         let msg = || {
             io::OutputMessage::Consensus(io::ConsensusReq {
@@ -417,49 +438,27 @@ async fn twins_receive_loop(
             })
         };
 
-        match message.recipient {
-            io::Target::Broadcast => match partitions_opt {
-                None => {
-                    tracing::info!(
-                        "broadcasting view={view_number} from={port} target=all kind={kind}"
-                    );
-                    for target_port in sends.keys() {
-                        send_or_stash(true, *target_port, msg());
-                    }
-                }
-                Some(ps) => {
-                    for p in ps {
-                        let can_send = p.contains(&port);
-                        tracing::info!("broadcasting view={view_number} from={port} target={p:?} kind={kind} can_send={can_send}");
-                        for target_port in p {
-                            send_or_stash(can_send, *target_port, msg());
-                        }
-                    }
-                }
-            },
-            io::Target::Validator(v) => {
-                let target_ports = &validator_ports[&v];
+        let can_send = |to| {
+            match router.can_send(&message, port, to) {
+                Some(can_send) => Ok(can_send),
+                None => bail!("ran out of port schedule; we probably wouldn't finalize blocks even if we continued")
+            }
+        };
 
-                match partitions_opt {
-                    None => {
-                        for target_port in target_ports {
-                            tracing::info!(
-                                "unicasting view={view_number} from={port} target={target_port} kind={kind}"
-                            );
-                            send_or_stash(true, *target_port, msg());
-                        }
-                    }
-                    Some(ps) => {
-                        for p in ps {
-                            let can_send = p.contains(&port);
-                            for target_port in target_ports {
-                                if p.contains(target_port) {
-                                    tracing::info!("unicasting view={view_number} from={port} target={target_port } kind={kind} can_send={can_send}");
-                                    send_or_stash(can_send, *target_port, msg());
-                                }
-                            }
-                        }
-                    }
+        match message.recipient {
+            io::Target::Broadcast => {
+                tracing::info!("broadcasting view={view_number} from={port} kind={kind}");
+                for target_port in sends.keys() {
+                    send_or_stash(can_send(*target_port)?, *target_port, msg());
+                }
+            }
+            io::Target::Validator(ref v) => {
+                let target_ports = &validator_ports[v];
+                tracing::info!(
+                    "unicasting view={view_number} from={port} target={target_ports:?} kind={kind}"
+                );
+                for target_port in target_ports {
+                    send_or_stash(can_send(*target_port)?, *target_port, msg());
                 }
             }
         }
@@ -564,6 +563,11 @@ fn input_msg_phase_number(msg: &io::ConsensusInputMessage) -> usize {
     };
     assert!(phase < NUM_PHASES);
     phase
+}
+
+/// View number of the message, to decide which partitioning to apply.
+fn input_msg_view_number(msg: &io::ConsensusInputMessage) -> usize {
+    msg.message.msg.view().number.0 as usize
 }
 
 struct TwinsGossipMessage {

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -10,7 +10,7 @@ use zksync_consensus_network::testonly::new_configs_for_validators;
 use zksync_consensus_roles::validator::{
     self,
     testonly::{Setup, SetupSpec},
-    LeaderSelectionMode, PublicKey, SecretKey,
+    LeaderSelectionMode, PublicKey, SecretKey, ViewNumber,
 };
 
 async fn run_test(behavior: Behavior, network: Network) {
@@ -437,6 +437,10 @@ async fn run_twins(
 /// should cause the others to finalize the block and gossip the payload to them in turn.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wait_for_finalized_deadlock() {
+    zksync_concurrency::testonly::abort_on_panic();
+    let _guard = zksync_concurrency::testonly::set_timeout(time::Duration::seconds(30));
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.0));
+
     // These are the conditions for the deadlock to occur:
     // * The problem happens in the handling of LeaderPrepare where the replica waits for the previous block in the justification.
     // * For that the replica needs to receive a proposal from a leader that knows the previous block is finalized.
@@ -447,26 +451,124 @@ async fn test_wait_for_finalized_deadlock() {
     // * In order for 2 leaders to be dow  and quorum still be possible, we need at least 11 nodes.
 
     // Here are a series of steps to reproduce the issue:
-    // 1. Say we have 11 nodes: [1,2,3,4,5,6,7,8,9,10,11], taking turns leading the views in that order; we need 9 nodes for quorum.
+    // 1. Say we have 11 nodes: [0,1,2,3,4,5,6,7,8,9,10], taking turns leading the views in that order; we need 9 nodes for quorum. The first view is view 1 lead by node 1.
     // 2. Node 1 sends LeaderPropose with block 1 to nodes [1-9] and puts together a HighQC.
     // 3. Node 1 sends the LeaderCommit to node 2, then dies.
-    // 4. Node 2 sends LeaderPropose with block 2 to nodes [10, 11], then dies.
-    // 5. Nodes [10,11] get stuck processing LeaderPropose because they are waiting for block 1 to appear in their stores.
-    // 6. Node 3 cannot gather 9 ReplicaPrepare messages for a quorum because nodes [1,2] are down and [10,11] are blocking. Consensus stalls.
+    // 4. Node 2 sends LeaderPropose with block 2 to nodes [0, 10], then dies.
+    // 5. Nodes [0, 10] get stuck processing LeaderPropose because they are waiting for block 1 to appear in their stores.
+    // 6. Node 3 cannot gather 9 ReplicaPrepare messages for a quorum because nodes [1,2] are down and [0,10] are blocking. Consensus stalls.
 
-    // Here are the steps we can take with the Twins network to simulate the above:
-    // * View 1:
-    //   * Phase 0: P1={1,2,3,4,5,6,7,8,9}, P2={10,11} -> Leader 1 sends LeaderPrepare(B1) to P1; P1 send ReplicaCommit(B1) to leader 1; leader 1 creates HighQC(B1)
-    //   * Phase 1: P1={1,2}, P2={3,4,5,6,7,8,9,10,11} -> Leader 1 sends LeaderCommit(B1) to P1
-    // * View 2:
-    //   * Phase 0: P1={1}, P2={2,3,4,5,6,7,8,9,10,11} -> Alas, if Leader 2 broadcasts its ReplicaPrepare it contains the HighQC already,
-    //                                                    which causes everyone to finalize the B1, but it can't send a LeaderPrepare(B2)
-    //                                                    without gathering 9 ReplicaPrepare from P2. It should not send its own ReplicaPrepare,
-    //                                                    and only send the LeaderPrepare to a subset of P2, but we only have the two phases.
-    //
-    // TODO: We need even more control than what the phases and partitions allow.
-    //       Wrap them up into an enum with a method that the runner delegates routing decisions to, e.g.
-    //       `allowed_targets(message, from) -> Option<&HashSet<Port>>`, or
-    //       `can_send(message, from, to) -> Option<bool>`, where `None` would indicate having no schedule for the view;
-    //       then add a new variant that has function predicate which describes exactly the above scenario.
+    // To simulate this with the Twins network we need to use a custom routing function, because the 2nd leader mustn't broadcast the HighQC
+    // to its peers, but it must receive their ReplicaPrepare's to be able to construct the PrepareQC; because of this the simple split schedule
+    // would not be enough as it allows sending messages in both directions.
+
+    let rng = &mut ctx.rng();
+
+    // We want the 2nd proposal to be finalised despite the waiting for block 1.
+    let blocks_to_finalize = 2;
+    let num_replicas = 11;
+    let gossip_peers = 1;
+
+    let mut spec = SetupSpec::new(rng, num_replicas);
+
+    let nodes = spec
+        .validator_weights
+        .iter()
+        .map(|(_, w)| (Behavior::Honest, *w))
+        .collect();
+
+    let nets = new_configs_for_validators(
+        rng,
+        spec.validator_weights.iter().map(|(sk, _)| sk),
+        gossip_peers,
+    );
+
+    // Assign the validator rota to be in the order of appearance, not ordered by public key.
+    spec.leader_selection = LeaderSelectionMode::Rota(
+        spec.validator_weights
+            .iter()
+            .map(|(sk, _)| sk.public())
+            .collect(),
+    );
+
+    let setup: Setup = spec.into();
+
+    let port_to_id = nets
+        .iter()
+        .enumerate()
+        .map(|(i, net)| (net.server_addr.port(), i))
+        .collect::<HashMap<_, _>>();
+
+    // Sanity check the leader schedule
+    {
+        let pk = setup.genesis.view_leader(ViewNumber(1));
+        let cfg = nets
+            .iter()
+            .find(|net| net.validator_key.as_ref().unwrap().public() == pk)
+            .unwrap();
+        let port = cfg.server_addr.port();
+        assert_eq!(port_to_id[&port], 1);
+    }
+
+    let router = PortRouter::Custom(Box::new(move |msg, from, to| {
+        use validator::ConsensusMsg::*;
+        // Map ports back to logical node ID
+        let from = port_to_id[&from];
+        let to = port_to_id[&to];
+        let view_number = msg.view().number;
+
+        // If we haven't finalised the blocks in the first few rounds, we failed.
+        if view_number.0 > 5 {
+            return None;
+        }
+
+        let can_send = match view_number {
+            ViewNumber(1) => {
+                match from {
+                    // Current leader
+                    1 => match msg {
+                        // Send the proposal to a subset of nodes
+                        LeaderPrepare(_) => to != 0 && to != 10,
+                        // Send the commit to the next leader only
+                        LeaderCommit(_) => to == 2,
+                        _ => true,
+                    },
+                    // Replicas
+                    _ => true,
+                }
+            }
+            ViewNumber(2) => match from {
+                // Previous leader is dead
+                1 => false,
+                // Current leader
+                2 => match msg {
+                    // Don't send out the HighQC to the others
+                    ReplicaPrepare(_) => false,
+                    // Send the proposal to the ones which didn't get the previous one
+                    LeaderPrepare(_) => to == 0 || to == 10,
+                    _ => true,
+                },
+                // Replicas
+                _ => true,
+            },
+            // Previous leaders dead
+            _ => from != 1 && from != 2,
+        };
+
+        // eprintln!(
+        //     "view={view_number} from={from} to={to} kind={} can_send={can_send}",
+        //     msg.label()
+        // );
+
+        Some(can_send)
+    }));
+
+    Test {
+        network: Network::Twins(router),
+        nodes,
+        blocks_to_finalize,
+    }
+    .run_with_config(ctx, nets, &setup.genesis)
+    .await
+    .unwrap()
 }

--- a/node/actors/bft/src/tests.rs
+++ b/node/actors/bft/src/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::testonly::{
     twins::{Cluster, HasKey, ScenarioGenerator, Twin},
     ut_harness::UTHarness,
-    Behavior, Network, PortSplitSchedule, Test, NUM_PHASES,
+    Behavior, Network, PortRouter, PortSplitSchedule, Test, NUM_PHASES,
 };
 use zksync_concurrency::{ctx, scope, time};
 use zksync_consensus_network::testonly::new_configs_for_validators;
@@ -420,7 +420,7 @@ async fn run_twins(
         }
 
         Test {
-            network: Network::Twins(splits),
+            network: Network::Twins(PortRouter::Splits(splits)),
             nodes: nodes.clone(),
             blocks_to_finalize,
         }
@@ -465,6 +465,8 @@ async fn test_wait_for_finalized_deadlock() {
     //                                                    and only send the LeaderPrepare to a subset of P2, but we only have the two phases.
     //
     // TODO: We need even more control than what the phases and partitions allow.
-    //       Wrap them up into an enum with a method `allowed_targets(&self, message, from) -> Option<&HashSet<Port>>` that the runner delegates to,
+    //       Wrap them up into an enum with a method that the runner delegates routing decisions to, e.g.
+    //       `allowed_targets(message, from) -> Option<&HashSet<Port>>`, or
+    //       `can_send(message, from, to) -> Option<bool>`, where `None` would indicate having no schedule for the view;
     //       then add a new variant that has function predicate which describes exactly the above scenario.
 }


### PR DESCRIPTION
## What ❔

- [x] Create a test to artificially create a situation in which some nodes have the proposal payload but not the CommitQC that would finalize it and allow it to be gossiped, while others have the HighQC received as part of a new proposal, but they don't have the previous payload and wait for it to be gossiped to them, creating a deadlock and stalling consensus. 
- [x] The solution is to timeout waiting for the block to appear in the store and move on to the new view, broadcast the HighQC as part of the ReplicaPrepare, which should allow the others to finalise the block.

## Why ❔

To deal with the loss of liveness caused by multiple leaders who owned both the payload and the CommitQC going down, and further replicas stop participating in consensus until they have the previous payload which never comes.
