### PR TITLE
made tests more deterministic

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -3825,6 +3825,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "rand 0.8.5",
+ "test-casing",
  "thiserror",
  "tokio",
  "tracing",

--- a/node/actors/bft/Cargo.toml
+++ b/node/actors/bft/Cargo.toml
@@ -24,9 +24,10 @@ tracing.workspace = true
 vise.workspace = true
 
 [dev-dependencies]
-tokio.workspace = true
+tokio = { workspace = true, features = ["full","test-util"]}
 assert_matches.workspace = true
 pretty_assertions.workspace = true
+test-casing.workspace = true
 
 [lints]
 workspace = true

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -1,5 +1,5 @@
 use super::{Behavior, Node};
-use anyhow::bail;
+use anyhow::Context as _;
 use network::{io, Config};
 use rand::seq::SliceRandom;
 use std::{
@@ -91,9 +91,29 @@ pub(crate) struct Test {
     pub(crate) blocks_to_finalize: usize,
 }
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum TestError {
+    #[error("finalized conflicting blocks")]
+    BlockConflict,
+    #[error(transparent)]
+    Other(#[from] ctx::Error),
+}
+
+impl From<anyhow::Error> for TestError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<ctx::Canceled> for TestError {
+    fn from(err: ctx::Canceled) -> Self {
+        Self::Other(err.into())
+    }
+}
+
 impl Test {
     /// Run a test with the given parameters and a random network setup.
-    pub(crate) async fn run(&self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
+    pub(crate) async fn run(&self, ctx: &ctx::Ctx) -> Result<(), TestError> {
         let rng = &mut ctx.rng();
         let setup = validator::testonly::Setup::new_with_weights(
             rng,
@@ -109,13 +129,13 @@ impl Test {
         ctx: &ctx::Ctx,
         nets: Vec<Config>,
         genesis: &validator::Genesis,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TestError> {
         let mut nodes = vec![];
         let mut honest = vec![];
         scope::run!(ctx, |ctx, s| async {
             for (i, net) in nets.into_iter().enumerate() {
                 let (store, runner) = new_store(ctx, genesis).await;
-                s.spawn_bg(runner.run(ctx));
+                s.spawn_bg(async { Ok(runner.run(ctx).await?) });
                 if self.nodes[i].0 == Behavior::Honest {
                     honest.push(store.clone());
                 }
@@ -126,7 +146,7 @@ impl Test {
                 });
             }
             assert!(!honest.is_empty());
-            s.spawn_bg(run_nodes(ctx, &self.network, &nodes));
+            s.spawn_bg(async { Ok(run_nodes(ctx, &self.network, &nodes).await?) });
 
             // Run the nodes until all honest nodes store enough finalized blocks.
             assert!(self.blocks_to_finalize > 0);
@@ -140,16 +160,15 @@ impl Test {
             for i in 0..self.blocks_to_finalize as u64 {
                 let i = first + i;
                 // Only comparing the payload; the justification might be different.
-                let want = honest[0]
-                    .block(ctx, i)
-                    .await?
-                    .expect("checked its existence")
-                    .payload;
+                let want = honest[0].block(ctx, i).await?.context("missing block")?;
                 for store in &honest[1..] {
-                    assert_eq!(want, store.block(ctx, i).await?.unwrap().payload);
+                    let got = store.block(ctx, i).await?.context("missing block")?;
+                    if want.payload != got.payload {
+                        return Err(TestError::BlockConflict);
+                    }
                 }
             }
-            Ok(())
+            Ok::<_, TestError>(())
         })
         .await
     }
@@ -445,7 +464,7 @@ async fn twins_receive_loop(
         let can_send = |to| {
             match router.can_send(&message.message.msg, port, to) {
                 Some(can_send) => Ok(can_send),
-                None => bail!("ran out of port schedule; we probably wouldn't finalize blocks even if we continued")
+                None => anyhow::bail!("ran out of port schedule; we probably wouldn't finalize blocks even if we continued")
             }
         };
 


### PR DESCRIPTION
Some of the tests were flaky because of cpu contention affecting interleavings. This fix makes the passing time (almost) deterministic, by the use of `tokio::time::pause()`. The other consequence is that runtime used in multiple tests has been changed from multi-threaded to single-threaded. This also helps the determinism because the nextest parallelism is bounded by the number of cores - if we make all tests single-threaded, behavior of the test will be the same when executed separately and in a test suite.

Also converted a should_panic test to regular test for consistency.
Tuned size of some of the tests to reasonable execution times.