### PR TITLE
FIX: Add missing colon to spec.yaml

### DIFF
--- a/.github/workflows/spec.yaml
+++ b/.github/workflows/spec.yaml
@@ -1,19 +1,18 @@
 name: Specification testing
 
-on: 
-  pull_request
-    paths: 
-      - 'spec/**'
+on:
+  pull_request:
+    paths:
+      - "spec/**"
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-    
+
       - name: Install node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## What ❔

Fixes invalid syntax in `spec.yaml`

## Why ❔

I don't know why it didn't fail on `main` but on my PR after merging `main` into it CI complained about `spec.yaml` having no workflow due to invalid syntax.