### PR TITLE
BFT-476: Change PersistentBatchStore methods to async

### DIFF
--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -132,7 +132,7 @@ impl PersistentBatchStore for BatchStore {
         self.0.persisted.subscribe()
     }
 
-    fn last_batch(&self) -> attester::BatchNumber {
+    async fn last_batch(&self) -> attester::BatchNumber {
         self.0
             .persisted
             .borrow()
@@ -142,22 +142,22 @@ impl PersistentBatchStore for BatchStore {
             .unwrap()
     }
 
-    fn last_batch_qc(&self) -> attester::BatchQC {
+    async fn last_batch_qc(&self) -> attester::BatchQC {
         let qcs = self.0.qcs.lock().unwrap();
         let last_batch_number = qcs.keys().max().unwrap();
         qcs.get(last_batch_number).unwrap().clone()
     }
 
-    fn get_batch_qc(&self, number: attester::BatchNumber) -> Option<attester::BatchQC> {
+    async fn get_batch_qc(&self, number: attester::BatchNumber) -> Option<attester::BatchQC> {
         let qcs = self.0.qcs.lock().unwrap();
         qcs.get(&number).cloned()
     }
 
-    fn store_qc(&self, qc: attester::BatchQC) {
+    async fn store_qc(&self, qc: attester::BatchQC) {
         self.0.qcs.lock().unwrap().insert(qc.message.number, qc);
     }
 
-    fn get_batch(&self, number: attester::BatchNumber) -> Option<attester::SyncBatch> {
+    async fn get_batch(&self, number: attester::BatchNumber) -> Option<attester::SyncBatch> {
         let batches = self.0.batches.lock().unwrap();
         let front = batches.front()?;
         let idx = number.0.checked_sub(front.number.0)?;

--- a/node/libs/storage/src/testonly/mod.rs
+++ b/node/libs/storage/src/testonly/mod.rs
@@ -173,14 +173,14 @@ pub async fn dump_batch(
         .map(|sb| sb.number.next())
         .unwrap_or(state.first);
     for n in (state.first.0..after.0).map(attester::BatchNumber) {
-        let batch = store.get_batch(n).unwrap();
+        let batch = store.get_batch(n).await.unwrap();
         assert_eq!(batch.number, n);
         batches.push(batch);
     }
     if let Some(before) = state.first.prev() {
-        assert!(store.get_batch(before).is_none());
+        assert!(store.get_batch(before).await.is_none());
     }
-    assert!(store.get_batch(after).is_none());
+    assert!(store.get_batch(after).await.is_none());
     batches
 }
 


### PR DESCRIPTION
## What ❔

Change the methods of `PersistentBatchStore` to be `async`.

## Why ❔

Because I want to implement them in the `zksync-era` repo and the DAL methods are async.
