### PR TITLE
BFT-476: Add ctx to PersistentBatchStore methods

### DIFF
--- a/node/libs/storage/src/batch_store.rs
+++ b/node/libs/storage/src/batch_store.rs
@@ -10,7 +10,7 @@ pub struct BatchStoreState {
     /// Stored batch with the lowest number.
     /// If last is `None`, this is the first batch that should be fetched.
     pub first: attester::BatchNumber,
-    /// Stored QC of the latest batch.
+    /// The last stored L1 batch.
     /// None iff store is empty.
     pub last: Option<attester::SyncBatch>,
 }

--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -132,7 +132,7 @@ impl PersistentBatchStore for BatchStore {
         self.0.persisted.subscribe()
     }
 
-    async fn last_batch(&self) -> attester::BatchNumber {
+    async fn last_batch(&self, _ctx: &ctx::Ctx) -> attester::BatchNumber {
         self.0
             .persisted
             .borrow()
@@ -142,22 +142,30 @@ impl PersistentBatchStore for BatchStore {
             .unwrap()
     }
 
-    async fn last_batch_qc(&self) -> attester::BatchQC {
+    async fn last_batch_qc(&self, _ctx: &ctx::Ctx) -> attester::BatchQC {
         let qcs = self.0.qcs.lock().unwrap();
         let last_batch_number = qcs.keys().max().unwrap();
         qcs.get(last_batch_number).unwrap().clone()
     }
 
-    async fn get_batch_qc(&self, number: attester::BatchNumber) -> Option<attester::BatchQC> {
+    async fn get_batch_qc(
+        &self,
+        _ctx: &ctx::Ctx,
+        number: attester::BatchNumber,
+    ) -> Option<attester::BatchQC> {
         let qcs = self.0.qcs.lock().unwrap();
         qcs.get(&number).cloned()
     }
 
-    async fn store_qc(&self, qc: attester::BatchQC) {
+    async fn store_qc(&self, _ctx: &ctx::Ctx, qc: attester::BatchQC) {
         self.0.qcs.lock().unwrap().insert(qc.message.number, qc);
     }
 
-    async fn get_batch(&self, number: attester::BatchNumber) -> Option<attester::SyncBatch> {
+    async fn get_batch(
+        &self,
+        _ctx: &ctx::Ctx,
+        number: attester::BatchNumber,
+    ) -> Option<attester::SyncBatch> {
         let batches = self.0.batches.lock().unwrap();
         let front = batches.front()?;
         let idx = number.0.checked_sub(front.number.0)?;

--- a/node/libs/storage/src/testonly/mod.rs
+++ b/node/libs/storage/src/testonly/mod.rs
@@ -173,14 +173,14 @@ pub async fn dump_batch(
         .map(|sb| sb.number.next())
         .unwrap_or(state.first);
     for n in (state.first.0..after.0).map(attester::BatchNumber) {
-        let batch = store.get_batch(ctx, n).await.unwrap();
+        let batch = store.get_batch(ctx, n).await.unwrap().unwrap();
         assert_eq!(batch.number, n);
         batches.push(batch);
     }
     if let Some(before) = state.first.prev() {
-        assert!(store.get_batch(ctx, before).await.is_none());
+        assert!(store.get_batch(ctx, before).await.unwrap().is_none());
     }
-    assert!(store.get_batch(ctx, after).await.is_none());
+    assert!(store.get_batch(ctx, after).await.unwrap().is_none());
     batches
 }
 

--- a/node/libs/storage/src/testonly/mod.rs
+++ b/node/libs/storage/src/testonly/mod.rs
@@ -160,7 +160,7 @@ pub async fn dump(ctx: &ctx::Ctx, store: &dyn PersistentBlockStore) -> Vec<valid
 
 /// Dumps all the batches stored in `store`.
 pub async fn dump_batch(
-    _ctx: &ctx::Ctx,
+    ctx: &ctx::Ctx,
     store: &dyn PersistentBatchStore,
 ) -> Vec<attester::SyncBatch> {
     // let genesis = store.genesis(ctx).await.unwrap();
@@ -173,14 +173,14 @@ pub async fn dump_batch(
         .map(|sb| sb.number.next())
         .unwrap_or(state.first);
     for n in (state.first.0..after.0).map(attester::BatchNumber) {
-        let batch = store.get_batch(n).await.unwrap();
+        let batch = store.get_batch(ctx, n).await.unwrap();
         assert_eq!(batch.number, n);
         batches.push(batch);
     }
     if let Some(before) = state.first.prev() {
-        assert!(store.get_batch(before).await.is_none());
+        assert!(store.get_batch(ctx, before).await.is_none());
     }
-    assert!(store.get_batch(after).await.is_none());
+    assert!(store.get_batch(ctx, after).await.is_none());
     batches
 }
 


### PR DESCRIPTION
## What ❔
Adds the `ctx` parameter to the methods of `PersistentBatchStore` and changes the return type to `ctx::Result`.

## Why ❔

Need them to implement the trait in https://github.com/matter-labs/zksync-era/pull/2340