### PR TITLE
Refactored TimeoutQC to contain just one CommitQC

### DIFF
--- a/spec/informal-spec/replica.rs
+++ b/spec/informal-spec/replica.rs
@@ -165,7 +165,7 @@ fn on_proposal(self, proposal: Proposal) {
     match proposal.justification {
         Commit(qc) => self.process_commit_qc(Some(qc)),
         Timeout(qc) => {
-            self.process_commit_qc(qc.high_qc());
+            self.process_commit_qc(qc.high_commit_qc);
             self.high_timeout_qc = max(Some(qc), self.high_timeout_qc);
         }
     };
@@ -177,7 +177,7 @@ fn on_proposal(self, proposal: Proposal) {
 // Processed an (already verified) commit_qc received from the network
 // as part of some message. It bumps the local high_commit_qc and if
 // we have the proposal corresponding to this qc, we append it to the committed_blocks.
-fn process_commit_qc(self, qc_opt: Option[CommitQC]) {
+fn process_commit_qc(self, qc_opt: Option<CommitQC>) {
     if let Some(qc) = qc_opt {
         self.high_commit_qc = max(Some(qc), self.high_commit_qc);
         let Some(block) = self.cached_proposals.get((qc.vote.block_number,qc.vote.block_hash)) else { return };

--- a/spec/informal-spec/replica.rs
+++ b/spec/informal-spec/replica.rs
@@ -218,7 +218,7 @@ fn on_timeout(self, sig_vote: SignedTimeoutVote) {
 
     // Check if we now have a timeout QC for this view.
     if let Some(qc) = self.get_timeout_qc(sig_vote.view()) {
-        self.process_commit_qc(qc.high_qc());
+        self.process_commit_qc(qc.high_commit_qc);
         self.high_timeout_qc = max(Some(qc), self.high_timeout_qc);
         self.start_new_view(sig_vote.view() + 1);
     }
@@ -235,7 +235,7 @@ fn on_new_view(self, new_view: NewView) {
     match new_view.justification {
         Commit(qc) => self.process_commit_qc(Some(qc)),
         Timeout(qc) => {
-            self.process_commit_qc(qc.high_qc());
+            self.process_commit_qc(qc.high_commit_qc);
             self.high_timeout_qc = max(Some(qc), self.high_timeout_qc);
         }
     };

--- a/spec/informal-spec/types.rs
+++ b/spec/informal-spec/types.rs
@@ -178,6 +178,7 @@ impl SignedTimeoutVote {
         // If we wish, there are two invariants that are easy to check but aren't required for correctness:
         // self.view() >= self.high_vote.view() && self.high_vote.view() >= self.high_commit_qc_view
         self.vote.high_commit_qc_view == self.high_commit_qc.map(|x| x.view()) && self.verify_sig()
+          && self.high_commit_qc.map(|qc| qc.verify())
     }
 }
 

--- a/spec/informal-spec/types.rs
+++ b/spec/informal-spec/types.rs
@@ -77,7 +77,7 @@ impl Justification {
 
                 // Get the high commit QC of the timeout QC. We compare the high QC field of
                 // all timeout votes in the QC, and get the highest one, if it exists.
-                let high_qc: Option<CommitQC> = qc.high_qc();
+                let high_qc: Option<CommitQC> = qc.high_commit_qc;
 
                 if high_vote.is_some()
                     && (high_qc.is_none() || high_vote.block_number > high_qc.block_number)


### PR DESCRIPTION
## What ❔

Refactored (in the informal spec) `TimeoutQC`, `SignedTimeoutVote` and `TimeoutVote` so that `TimeoutQC` contains only one `CommitQC` (the high QC).

## Why ❔

It reduces the state space which should help with model checking.
