### PR TITLE
feat: Collect votes for batch QC and save into store (BFT-477)

### DIFF
--- a/node/actors/network/src/gossip/batch_votes.rs
+++ b/node/actors/network/src/gossip/batch_votes.rs
@@ -25,14 +25,17 @@ pub(crate) struct BatchVotes {
     /// the quorum to be reached, but eventually we'll have to allow multiple
     /// votes across different heights.
     pub(crate) votes: im::HashMap<attester::PublicKey, Arc<attester::Signed<Batch>>>,
+
     /// Total weight of votes at different heights and hashes.
     ///
     /// We will be looking for any hash that reaches a quorum threshold at any of the heights.
     /// At that point we can remove all earlier heights, considering it final. In the future
     /// we can instead keep heights until they are observed on the main node (or L1).
-    support: im::OrdMap<attester::BatchNumber, im::HashMap<attester::BatchHash, attester::Weight>>,
+    pub(crate) support:
+        im::OrdMap<attester::BatchNumber, im::HashMap<attester::BatchHash, attester::Weight>>,
+
     /// The minimum batch number for which we are still interested in votes.
-    min_batch_number: attester::BatchNumber,
+    pub(crate) min_batch_number: attester::BatchNumber,
 }
 
 impl BatchVotes {

--- a/node/actors/network/src/gossip/batch_votes.rs
+++ b/node/actors/network/src/gossip/batch_votes.rs
@@ -4,19 +4,43 @@ use std::{collections::HashSet, sync::Arc};
 use zksync_concurrency::sync;
 use zksync_consensus_roles::attester::{self, Batch};
 
-/// Mapping from attester::PublicKey to a signed attester::Batch message.
 /// Represents the currents state of node's knowledge about the attester votes.
+///
+/// Eventually this data structure will have to track voting potentially happening
+/// simultaneously on multiple heights, if we decrease the batch interval to be
+/// several seconds, instead of a minute. By that point, the replicas should be
+/// following the main node (or L1) to know what is the highest finalized batch,
+/// which will act as a floor to the batch number we have to track here. It will
+/// also help to protect ourselves from DoS attacks by malicious attesters casting
+/// votes far into the future.
+///
+/// For now, however, we just want a best effort where if we find a quorum, we
+/// save it to the database, if not, we move on. For that, a simple protection
+/// mechanism is to only allow one active vote per attester, which means any
+/// previous vote can be removed when a new one is added.
 #[derive(Clone, Default, PartialEq, Eq)]
-pub(crate) struct BatchVotes(
-    pub(super) im::HashMap<attester::PublicKey, Arc<attester::Signed<Batch>>>,
-);
+pub(crate) struct BatchVotes {
+    /// The minimum batch number for which we are still intersted in votes.
+    min_batch_number: attester::BatchNumber,
+    /// The latest vote received from each attester. We only keep the last one
+    /// for now, hoping that with 1 minute batches there's plenty of time for
+    /// the quorum to be reached, but eventually we'll have to allow multiple
+    /// votes across different heights.
+    votes: im::HashMap<attester::PublicKey, Arc<attester::Signed<Batch>>>,
+    /// Total weight of votes at different heights and hashes.
+    ///
+    /// We will be looking for any hash that reaches a quorum threshold at any of the heights.
+    /// At that point we can remove all earlier heights, considering it final. In the future
+    /// we can instead keep heights until they are observed on the main node (or L1).
+    support: im::OrdMap<attester::BatchNumber, im::HashMap<attester::BatchHash, attester::Weight>>,
+}
 
 impl BatchVotes {
-    /// Returns a set of entries of `self` which are newer than the entries in `b`.
+    /// Returns a set of votes of `self` which are newer than the entries in `b`.
     pub(super) fn get_newer(&self, b: &Self) -> Vec<Arc<attester::Signed<Batch>>> {
         let mut newer = vec![];
-        for (k, v) in &self.0 {
-            if let Some(bv) = b.0.get(k) {
+        for (k, v) in &self.votes {
+            if let Some(bv) = b.votes.get(k) {
                 if v.msg <= bv.msg {
                     continue;
                 }
@@ -47,22 +71,118 @@ impl BatchVotes {
                 anyhow::bail!("duplicate entry for {:?}", d.key);
             }
             done.insert(d.key.clone());
-            if !attesters.contains(&d.key) {
+
+            if d.msg.number < self.min_batch_number {
+                continue;
+            }
+
+            let Some(weight) = attesters.weight(&d.key) else {
                 // We just skip the entries we are not interested in.
                 // For now the set of attesters is static, so we could treat this as an error,
                 // however we eventually want the attester set to be dynamic.
                 continue;
-            }
-            if let Some(x) = self.0.get(&d.key) {
+            };
+
+            // If we already have a newer vote for this key, we can ignore this one.
+            if let Some(x) = self.votes.get(&d.key) {
                 if d.msg <= x.msg {
                     continue;
                 }
             }
+
+            // Check the signature before insertion.
             d.verify()?;
-            self.0.insert(d.key.clone(), d.clone());
+
+            self.add(d.clone(), weight);
+
             changed = true;
         }
         Ok(changed)
+    }
+
+    /// Check if we have achieved quorum for any of the batch hashes.
+    ///
+    /// The return value is a vector because eventually we will be potentially waiting for
+    /// quorums on multiple heights simultaneously.
+    ///
+    /// For repeated queries we can supply a skip list of heights for which we alredy saved the QC.
+    pub(super) fn find_quorums(
+        &mut self,
+        attesters: &attester::Committee,
+        skip: HashSet<attester::BatchNumber>,
+    ) -> Vec<attester::BatchQC> {
+        let threshold = attesters.threshold();
+        self.support
+            .iter()
+            .filter(|(number, _)| !skip.contains(number))
+            .flat_map(|(number, candidates)| {
+                candidates
+                    .iter()
+                    .filter(|(_, weight)| **weight >= threshold)
+                    .map(|(hash, _)| {
+                        let sigs = self
+                            .votes
+                            .values()
+                            .filter(|vote| vote.msg.hash == *hash)
+                            .map(|vote| (vote.key.clone(), vote.sig.clone()))
+                            .fold(attester::MultiSig::default(), |mut sigs, (key, sig)| {
+                                sigs.add(key, sig);
+                                sigs
+                            });
+                        attester::BatchQC {
+                            message: Batch {
+                                number: *number,
+                                hash: *hash,
+                            },
+                            signatures: sigs,
+                        }
+                    })
+            })
+            .collect()
+    }
+
+    /// Set the minimum batch number for which we admit votes.
+    ///
+    /// Discards data about earlier heights.
+    pub(super) fn set_min_batch_number(&mut self, min_batch_number: attester::BatchNumber) {
+        self.min_batch_number = min_batch_number;
+        self.votes.retain(|_, v| v.msg.number >= min_batch_number);
+        if let Some(prev) = min_batch_number.prev() {
+            let (_, support) = self.support.split(&prev);
+            self.support = support;
+        }
+    }
+
+    /// Add an already validated vote from an attester into the register.
+    fn add(&mut self, vote: Arc<attester::Signed<Batch>>, weight: attester::Weight) {
+        self.remove(&vote.key, weight);
+
+        let batch = self.support.entry(vote.msg.number).or_default();
+        let support = batch.entry(vote.msg.hash).or_default();
+        *support = support.saturating_add(weight);
+
+        self.votes.insert(vote.key.clone(), vote);
+    }
+
+    /// Remove any existing vote.
+    ///
+    /// This for for DoS protection, until we have a better control on the acceptable vote range.
+    fn remove(&mut self, key: &attester::PublicKey, weight: attester::Weight) {
+        let Some(vote) = self.votes.remove(&key) else {
+            return;
+        };
+
+        let batch = self.support.entry(vote.msg.number).or_default();
+        let support = batch.entry(vote.msg.hash).or_default();
+        *support = support.saturating_sub(weight);
+
+        if *support == 0u64 {
+            batch.remove(&vote.msg.hash);
+        }
+
+        if batch.is_empty() {
+            self.support.remove(&vote.msg.number);
+        }
     }
 }
 

--- a/node/actors/network/src/gossip/batch_votes.rs
+++ b/node/actors/network/src/gossip/batch_votes.rs
@@ -166,7 +166,7 @@ impl BatchVotes {
 
     /// Remove any existing vote.
     ///
-    /// This for for DoS protection, until we have a better control on the acceptable vote range.
+    /// This is for DoS protection, until we have better control over the acceptable vote range.
     fn remove(&mut self, key: &attester::PublicKey, weight: attester::Weight) {
         let Some(vote) = self.votes.remove(key) else {
             return;

--- a/node/actors/network/src/gossip/mod.rs
+++ b/node/actors/network/src/gossip/mod.rs
@@ -17,11 +17,10 @@ use self::batch_votes::BatchVotesWatch;
 use crate::{gossip::ValidatorAddrsWatch, io, pool::PoolWatch, Config, MeteredStreamStats};
 use anyhow::Context as _;
 use fetch::RequestItem;
-use im::HashMap;
 use std::sync::{atomic::AtomicUsize, Arc};
 pub(crate) use validator_addrs::*;
 use zksync_concurrency::{ctx, ctx::channel, scope, sync};
-use zksync_consensus_roles::{attester, node, validator};
+use zksync_consensus_roles::{node, validator};
 use zksync_consensus_storage::{BatchStore, BlockStore};
 
 mod batch_votes;
@@ -57,10 +56,6 @@ pub(crate) struct Network {
     ///
     /// These are blocks that this node wants to request from remote peers via RPC.
     pub(crate) fetch_queue: fetch::Queue,
-    /// Last viewed QC.
-    pub(crate) last_viewed_qc: Option<attester::BatchQC>,
-    /// L1 batch qc.
-    pub(crate) batch_qc: HashMap<attester::BatchNumber, attester::BatchQC>,
     /// TESTONLY: how many time push_validator_addrs rpc was called by the peers.
     pub(crate) push_validator_addrs_calls: AtomicUsize,
 }
@@ -82,8 +77,6 @@ impl Network {
             outbound: PoolWatch::new(cfg.gossip.static_outbound.keys().cloned().collect(), 0),
             validator_addrs: ValidatorAddrsWatch::default(),
             batch_votes: Arc::new(BatchVotesWatch::default()),
-            batch_qc: HashMap::new(),
-            last_viewed_qc: None,
             cfg,
             fetch_queue: fetch::Queue::default(),
             block_store,
@@ -155,65 +148,34 @@ impl Network {
         .await;
     }
 
-    /// Task that keeps hearing about new votes and updates the L1 batch qc.
+    /// Task that keeps hearing about new votes and looks for an L1 batch qc.
     /// It will propagate the QC if there's enough votes.
-    pub(crate) async fn update_batch_qc(&self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
-        // TODO This is not a good way to do this, we shouldn't be verifying the QC every time
-        // Can we get only the latest votes?
-        let _attesters = self.genesis().attesters.as_ref().context("attesters")?;
+    pub(crate) async fn run_batch_qc_finder(&self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
+        let attesters = self.genesis().attesters.as_ref().context("attesters")?;
+        let mut sub = self.batch_votes.subscribe();
         loop {
-            let mut sub = self.batch_votes.subscribe();
-            let _votes = sync::changed(ctx, &mut sub)
-                .await
-                .context("batch votes")?
-                .clone();
+            // In the future when we might be gossiping about multiple batches at the same time,
+            // we can collect the ones we submitted into a skip list until we see them confirmed
+            // on L1 and we can finally increase the minimum as well.
+            let quorums = {
+                let votes = sync::changed(ctx, &mut sub).await.context("batch votes")?;
+                votes.find_quorums(attesters, |_| false)
+            };
 
-            // TODO: Look for a batch which is supported by a threshold of votes.
+            for qc in quorums {
+                // TODO: In the future this should come from confirmations, but for now it's best effort.
+                // TODO: An initial value could be looked up in the database even now.
+                let next_batch_number = qc.message.number.next();
 
-            // Check next QC to collect votes for.
-            // let new_qc = self
-            //     .last_viewed_qc
-            //     .clone()
-            //     .map(|qc| {
-            //         attester::BatchQC::new(attester::Batch {
-            //             number: qc.message.number.next(),
-            //         })
-            //     })
-            //     .unwrap_or_else(|| {
-            //         attester::BatchQC::new(attester::Batch {
-            //             number: attester::BatchNumber(0),
-            //         })
-            //     })
-            //     .context("new qc")?;
+                self.batch_store
+                    .queue_batch_qc(ctx, qc)
+                    .await
+                    .context("queue_batch_qc")?;
 
-            // // Check votes for the correct QC.
-            // for (_, sig) in votes.0 {
-            //     if self
-            //         .batch_qc
-            //         .clone()
-            //         .entry(new_qc.message.number)
-            //         .or_insert_with(|| attester::BatchQC::new(new_qc.message.clone()).expect("qc"))
-            //         .add(&sig, self.genesis())
-            //         .is_err()
-            //     {
-            //         // TODO: Should we ban the peer somehow?
-            //         continue;
-            //     }
-            // }
-
-            // let weight = attesters.weight_of_keys(
-            //     self.batch_qc
-            //         .get(&new_qc.message.number)
-            //         .context("last qc")?
-            //         .signatures
-            //         .keys(),
-            // );
-
-            // if weight < attesters.threshold() {
-            //     return Ok(());
-            // };
-
-            // If we have enough weight, we can update the last viewed QC and propagate it.
+                self.batch_votes
+                    .set_min_batch_number(next_batch_number)
+                    .await;
+            }
         }
     }
 }

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -665,9 +665,11 @@ fn test_batch_votes_quorum() {
 
         votes.set_min_batch_number(last_batch);
         assert!(votes.votes.values().all(|v| v.msg.number >= last_batch));
+        assert!(votes.support.keys().all(|n| *n >= last_batch));
 
         votes.set_min_batch_number(last_batch.next());
         assert!(votes.votes.is_empty());
+        assert!(votes.support.is_empty());
     }
 }
 

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -22,7 +22,7 @@ use zksync_concurrency::{
     time,
 };
 use zksync_consensus_roles::{attester, validator};
-use zksync_consensus_storage::testonly::TestMemoryStorage;
+use zksync_consensus_storage::{testonly::TestMemoryStorage, PersistentBatchStore};
 
 mod fetch_batches;
 mod fetch_blocks;
@@ -630,7 +630,8 @@ fn test_batch_votes_quorum() {
 
         let mut votes = BatchVotes::default();
         for sk in &keys {
-            let b = if rng.gen_range(0..100) < 80 { 1 } else { 0 };
+            // We need 4/5+1 for quorum, so let's say ~80% vote on the second batch.
+            let b = usize::from(rng.gen_range(0..100) < 80);
             let batch = &batches[b].0;
             let vote = sk.sign_msg(batch.clone());
             votes.update(&attesters, &[Arc::new(vote)]).unwrap();
@@ -670,9 +671,75 @@ fn test_batch_votes_quorum() {
     }
 }
 
-// TODO: This test is disabled because the logic for attesters to receive and sign batches is not implemented yet.
-// It should be re-enabled once the logic is implemented.
-// #[tokio::test(flavor = "multi_thread")]
-// async fn test_batch_votes_propagation() {
-// TODO: Implement this now that we can update the votes.
-// }
+//
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_votes_propagation() {
+    let _guard = set_timeout(time::Duration::seconds(10));
+    abort_on_panic();
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.));
+    let rng = &mut ctx.rng();
+
+    let mut setup = validator::testonly::Setup::new(rng, 10);
+
+    let cfgs = testonly::new_configs(rng, &setup, 1);
+
+    scope::run!(ctx, |ctx, s| async {
+        // All nodes share the same in-memory store
+        let store = TestMemoryStorage::new(ctx, &setup.genesis).await;
+        s.spawn_bg(store.runner.run(ctx));
+
+        // Push the first batch into the store so we have something to vote on.
+        setup.push_blocks(rng, 2);
+        setup.push_batch(rng);
+
+        let batch = setup.batches[0].clone();
+
+        store
+            .batches
+            .queue_batch(ctx, batch.clone(), setup.genesis.clone())
+            .await
+            .unwrap();
+
+        let batch = attester::Batch {
+            number: batch.number,
+            hash: rng.gen(),
+        };
+
+        // Start all nodes.
+        let nodes: Vec<testonly::Instance> = cfgs
+            .iter()
+            .enumerate()
+            .map(|(i, cfg)| {
+                let (node, runner) = testonly::Instance::new(
+                    cfg.clone(),
+                    store.blocks.clone(),
+                    store.batches.clone(),
+                );
+                s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("node", i)));
+                node
+            })
+            .collect();
+
+        // Cast votes on each node. It doesn't matter who signs where in this test,
+        // we just happen to know that we'll have as many nodes as attesters.
+        let attesters = setup.genesis.attesters.as_ref().unwrap();
+        for (node, key) in nodes.iter().zip(setup.attester_keys.iter()) {
+            node.net
+                .batch_vote_publisher()
+                .publish(attesters, key, batch.clone())
+                .await
+                .unwrap();
+        }
+
+        // Wait until one of the nodes collects a quorum over gossip and stores.
+        loop {
+            if let Some(qc) = store.im_batches.get_batch_qc(ctx, batch.number).await? {
+                assert_eq!(qc.message, batch);
+                return Ok(());
+            }
+            ctx.sleep(time::Duration::milliseconds(100)).await?;
+        }
+    })
+    .await
+    .unwrap();
+}

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -554,7 +554,7 @@ async fn test_batch_votes() {
         want.insert(random_batch_vote(rng, k));
     }
     votes.update(&attesters, &want.as_vec()).await.unwrap();
-    assert_eq!(want.0, sub.borrow_and_update().0);
+    assert_eq!(want.0, sub.borrow_and_update().votes);
 
     // newer batch number
     let k0v2 = update_signature(rng, &want.get(&keys[0]).msg, &keys[0], 1);
@@ -581,7 +581,7 @@ async fn test_batch_votes() {
         k8v1.clone(),
     ];
     votes.update(&attesters, &update).await.unwrap();
-    assert_eq!(want.0, sub.borrow_and_update().0);
+    assert_eq!(want.0, sub.borrow_and_update().votes);
 
     // Invalid signature.
     let mut k0v3 = mk_batch(
@@ -591,18 +591,19 @@ async fn test_batch_votes() {
     );
     k0v3.key = keys[0].public();
     assert!(votes.update(&attesters, &[Arc::new(k0v3)]).await.is_err());
-    assert_eq!(want.0, sub.borrow_and_update().0);
+    assert_eq!(want.0, sub.borrow_and_update().votes);
 
     // Duplicate entry in the update.
     assert!(votes
         .update(&attesters, &[k8v1.clone(), k8v1])
         .await
         .is_err());
-    assert_eq!(want.0, sub.borrow_and_update().0);
+    assert_eq!(want.0, sub.borrow_and_update().votes);
 }
 
 // TODO: This test is disabled because the logic for attesters to receive and sign batches is not implemented yet.
 // It should be re-enabled once the logic is implemented.
 // #[tokio::test(flavor = "multi_thread")]
 // async fn test_batch_votes_propagation() {
+// TODO: Implement this now that we can update the votes.
 // }

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -107,11 +107,14 @@ fn mk_netaddr(
 }
 
 fn mk_batch<R: Rng>(
-    _rng: &mut R,
+    rng: &mut R,
     key: &attester::SecretKey,
     number: attester::BatchNumber,
 ) -> attester::Signed<attester::Batch> {
-    key.sign_msg(attester::Batch { number })
+    key.sign_msg(attester::Batch {
+        number,
+        hash: rng.gen(),
+    })
 }
 
 fn random_netaddr<R: Rng>(
@@ -132,6 +135,7 @@ fn random_batch_vote<R: Rng>(
 ) -> Arc<attester::Signed<attester::Batch>> {
     let batch = attester::Batch {
         number: attester::BatchNumber(rng.gen_range(0..1000)),
+        hash: rng.gen(),
     };
     Arc::new(key.sign_msg(batch.to_owned()))
 }
@@ -152,13 +156,14 @@ fn update_netaddr<R: Rng>(
 }
 
 fn update_signature<R: Rng>(
-    _rng: &mut R,
+    rng: &mut R,
     batch: &attester::Batch,
     key: &attester::SecretKey,
     batch_number_diff: i64,
 ) -> Arc<attester::Signed<attester::Batch>> {
     let batch = attester::Batch {
         number: attester::BatchNumber((batch.number.0 as i64 + batch_number_diff) as u64),
+        hash: rng.gen(),
     };
     Arc::new(key.sign_msg(batch.to_owned()))
 }

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -132,8 +132,10 @@ impl Runner {
 
             // Update QC batches in the background.
             s.spawn(async {
-                self.net.gossip.run_batch_qc_finder(ctx).await?;
-                Ok(())
+                match self.net.gossip.run_batch_qc_finder(ctx).await {
+                    Err(ctx::Error::Canceled(_)) => Ok(()),
+                    other => other,
+                }
             });
 
             // Fetch missing batches in the background.

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -133,6 +133,7 @@ impl Runner {
             // Update QC batches in the background.
             s.spawn(async {
                 // TODO: Handle this correctly.
+                // I guess the idea is to react to changes in `gossip.batch_votes` by looking for a quorum.
                 let _ = self.net.gossip.update_batch_qc(ctx).await;
                 Ok(())
             });

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -132,9 +132,7 @@ impl Runner {
 
             // Update QC batches in the background.
             s.spawn(async {
-                // TODO: Handle this correctly.
-                // I guess the idea is to react to changes in `gossip.batch_votes` by looking for a quorum.
-                let _ = self.net.gossip.update_batch_qc(ctx).await;
+                self.net.gossip.run_batch_qc_finder(ctx).await?;
                 Ok(())
             });
 

--- a/node/actors/network/src/tests.rs
+++ b/node/actors/network/src/tests.rs
@@ -28,15 +28,12 @@ async fn test_metrics() {
             .collect();
         testonly::instant_network(ctx, nodes.iter()).await?;
 
-        eprintln!("network finished, checking metrics");
-
         let registry = vise::MetricsCollection::default().collect();
         nodes[0].state().register_metrics();
         let mut encoded_metrics = String::new();
         registry.encode(&mut encoded_metrics, vise::Format::OpenMetricsForPrometheus)?;
         tracing::info!("stats =\n{encoded_metrics}");
 
-        eprintln!("nice, tests passed");
         Ok(())
     })
     .await

--- a/node/actors/network/src/tests.rs
+++ b/node/actors/network/src/tests.rs
@@ -28,11 +28,15 @@ async fn test_metrics() {
             .collect();
         testonly::instant_network(ctx, nodes.iter()).await?;
 
+        eprintln!("network finished, checking metrics");
+
         let registry = vise::MetricsCollection::default().collect();
         nodes[0].state().register_metrics();
         let mut encoded_metrics = String::new();
         registry.encode(&mut encoded_metrics, vise::Format::OpenMetricsForPrometheus)?;
         tracing::info!("stats =\n{encoded_metrics}");
+
+        eprintln!("nice, tests passed");
         Ok(())
     })
     .await

--- a/node/libs/roles/src/attester/keys/secret_key.rs
+++ b/node/libs/roles/src/attester/keys/secret_key.rs
@@ -1,5 +1,5 @@
 use super::{PublicKey, Signature};
-use crate::attester::{Batch, Msg, MsgHash, Signed};
+use crate::attester::{Msg, MsgHash, Signed};
 use std::{fmt, sync::Arc};
 use zksync_consensus_crypto::{secp256k1, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::Variant;
@@ -22,7 +22,7 @@ impl SecretKey {
     }
 
     /// Signs a batch message.
-    pub fn sign_msg<V>(&self, msg: Batch) -> Signed<V>
+    pub fn sign_msg<V>(&self, msg: V) -> Signed<V>
     where
         V: Variant<Msg>,
     {

--- a/node/libs/roles/src/attester/keys/secret_key.rs
+++ b/node/libs/roles/src/attester/keys/secret_key.rs
@@ -28,8 +28,6 @@ impl SecretKey {
     {
         let msg = msg.insert();
         Signed {
-            // TODO: This is supposed to be verifyable in Solidity.
-            // Making it into a protobuf message is probably not the way to go.
             sig: self.sign_hash(&msg.hash()),
             key: self.public(),
             msg: V::extract(msg).unwrap(),

--- a/node/libs/roles/src/attester/keys/secret_key.rs
+++ b/node/libs/roles/src/attester/keys/secret_key.rs
@@ -28,6 +28,8 @@ impl SecretKey {
     {
         let msg = msg.insert();
         Signed {
+            // TODO: This is supposed to be verifyable in Solidity.
+            // Making it into a protobuf message is probably not the way to go.
             sig: self.sign_hash(&msg.hash()),
             key: self.public(),
             msg: V::extract(msg).unwrap(),

--- a/node/libs/roles/src/attester/messages/batch.rs
+++ b/node/libs/roles/src/attester/messages/batch.rs
@@ -134,11 +134,11 @@ pub enum BatchQCAddError {
 
 impl BatchQC {
     /// Create a new empty instance for a given `Batch` message.
-    pub fn new(message: Batch) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(message: Batch) -> Self {
+        Self {
             message,
             signatures: attester::MultiSig::default(),
-        })
+        }
     }
 
     /// Add a attester's signature.

--- a/node/libs/roles/src/attester/messages/msg.rs
+++ b/node/libs/roles/src/attester/messages/msg.rs
@@ -14,6 +14,9 @@ pub enum Msg {
 
 impl Msg {
     /// Returns the hash of the message.
+    ///
+    /// TODO: Eventually this should be a hash over an ABI encoded payload that
+    /// can be verified in Solidity.
     pub fn hash(&self) -> MsgHash {
         MsgHash(keccak256::Keccak256::new(&zksync_protobuf::canonical(self)))
     }
@@ -154,9 +157,15 @@ impl Committee {
     /// Compute the sum of weights of as a list of public keys.
     ///
     /// The method assumes that the keys are unique and does not de-duplicate.
+    pub fn weight(&self, key: &attester::PublicKey) -> Option<u64> {
+        self.index(key).map(|i| self.vec[i].weight)
+    }
+
+    /// Compute the sum of weights of as a list of public keys.
+    ///
+    /// The method assumes that the keys are unique and does not de-duplicate.
     pub fn weight_of_keys<'a>(&self, keys: impl Iterator<Item = &'a attester::PublicKey>) -> u64 {
-        keys.filter_map(|pk| self.index(pk).map(|i| self.vec[i].weight))
-            .sum()
+        keys.filter_map(|key| self.weight(key)).sum()
     }
 
     /// Compute the sum of weights of signers given as a bit vector.
@@ -262,5 +271,8 @@ pub struct WeightedAttester {
     /// Attester key
     pub key: attester::PublicKey,
     /// Attester weight inside the Committee.
-    pub weight: u64,
+    pub weight: Weight,
 }
+
+/// Voting weight.
+pub type Weight = u64;

--- a/node/libs/roles/src/attester/testonly.rs
+++ b/node/libs/roles/src/attester/testonly.rs
@@ -1,6 +1,7 @@
 use super::{
-    AggregateMultiSig, AggregateSignature, Batch, BatchNumber, BatchQC, Committee, Msg, MsgHash,
-    MultiSig, PublicKey, SecretKey, Signature, Signed, Signers, SyncBatch, WeightedAttester,
+    AggregateMultiSig, AggregateSignature, Batch, BatchHash, BatchNumber, BatchQC, Committee, Msg,
+    MsgHash, MultiSig, PublicKey, SecretKey, Signature, Signed, Signers, SyncBatch,
+    WeightedAttester,
 };
 use crate::validator::Payload;
 use bit_vec::BitVec;
@@ -48,7 +49,10 @@ impl Distribution<Committee> for Standard {
 
 impl Distribution<Batch> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Batch {
-        Batch { number: rng.gen() }
+        Batch {
+            number: rng.gen(),
+            hash: rng.gen(),
+        }
     }
 }
 
@@ -69,15 +73,17 @@ impl Distribution<BatchNumber> for Standard {
     }
 }
 
+impl Distribution<BatchHash> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BatchHash {
+        BatchHash(rng.gen())
+    }
+}
+
 impl Distribution<BatchQC> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BatchQC {
-        let mut signatures = MultiSig::default();
-        for _ in 0..rng.gen_range(0..5) {
-            signatures.add(rng.gen(), rng.gen());
-        }
         BatchQC {
             message: rng.gen(),
-            signatures,
+            signatures: rng.gen(),
         }
     }
 }
@@ -97,6 +103,16 @@ impl Distribution<Signers> for Standard {
 impl Distribution<Signature> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Signature {
         Signature(rng.gen())
+    }
+}
+
+impl Distribution<MultiSig> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MultiSig {
+        let mut sig = MultiSig::default();
+        for _ in 0..rng.gen_range(0..5) {
+            sig.add(rng.gen(), rng.gen());
+        }
+        sig
     }
 }
 

--- a/node/libs/roles/src/attester/testonly.rs
+++ b/node/libs/roles/src/attester/testonly.rs
@@ -131,7 +131,11 @@ impl Distribution<AggregateMultiSig> for Standard {
     }
 }
 
-impl<V: Variant<Msg>> Distribution<Signed<V>> for Standard {
+impl<V> Distribution<Signed<V>> for Standard
+where
+    V: Variant<Msg>,
+    Standard: Distribution<V>,
+{
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Signed<V> {
         rng.gen::<SecretKey>().sign_msg(rng.gen())
     }

--- a/node/libs/roles/src/attester/tests.rs
+++ b/node/libs/roles/src/attester/tests.rs
@@ -169,7 +169,7 @@ fn test_batch_qc() {
 
     // Create QCs with increasing number of attesters.
     for i in 0..setup1.attester_keys.len() + 1 {
-        let mut qc = BatchQC::new(make_batch_msg(rng)).unwrap();
+        let mut qc = BatchQC::new(make_batch_msg(rng));
         for key in &setup1.attester_keys[0..i] {
             qc.add(&key.sign_msg(qc.message.clone()), &setup1.genesis)
                 .unwrap();
@@ -202,7 +202,7 @@ fn test_attester_committee_weights() {
     let sums = [1000, 1600, 2400, 8400, 9300, 10000];
 
     let msg = make_batch_msg(rng);
-    let mut qc = BatchQC::new(msg.clone()).unwrap();
+    let mut qc = BatchQC::new(msg.clone());
     for (n, weight) in sums.iter().enumerate() {
         let key = &setup.attester_keys[n];
         qc.add(&key.sign_msg(msg.clone()), &setup.genesis).unwrap();

--- a/node/libs/roles/src/attester/tests.rs
+++ b/node/libs/roles/src/attester/tests.rs
@@ -135,7 +135,7 @@ fn test_agg_signature_verify() {
 }
 
 fn make_batch_msg(rng: &mut impl Rng) -> Batch {
-    Batch { number: rng.gen() }
+    rng.gen()
 }
 
 #[test]

--- a/node/libs/roles/src/proto/attester.proto
+++ b/node/libs/roles/src/proto/attester.proto
@@ -10,8 +10,14 @@ message SyncBatch {
   optional bytes proof = 3; // required
 }
 
+message BatchHash {
+  optional bytes keccak256 = 1; // required
+}
+
+
 message Batch {
   optional uint64 number = 1; // required
+  optional BatchHash hash = 2; // required
 }
 
 message BatchQC {

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -527,5 +527,8 @@ pub struct WeightedValidator {
     /// Validator key
     pub key: validator::PublicKey,
     /// Validator weight inside the Committee.
-    pub weight: u64,
+    pub weight: Weight,
 }
+
+/// Voting weight;
+pub type Weight = u64;


### PR DESCRIPTION
## What ❔

- [x] Added `BatchHash` and `Batch::hash` to give meaning to the attestation
- [x] Refactored `BatchVotes` to look for a quorum over a height+hash combo
- [x] Added a background task to listen to changes in the votes, look for a quorum and save it to the DB
- [x] Test the quorum logic
- [x] Test the propagation

### Caveat

`BatchVotes` still only allows 1 vote per attester and thus doesn't fully handle multiple outstanding L1 batches. That will come later when we'll have subscribed to notifications about the highest finalised batch number, coming from the main node API which doesn't exist yet. That will serve as our beacon for what kind of ranges of votes to accept. Currently for defensive reasons we only accept one vote per attester, which means if attesters keep voting on different heights, always out of sync with each other, they might never form a quorum. That is considered okay at this point; we save what we can and see how it works. 1 minute batches should be long enough not to cause trouble for gossip.

## Why ❔

With these changes the node will react to votes coming in over gossip and forming a quorum over the latest L1 batch. 