### PR TITLE
chore: Prepare crates for publishing

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -2124,8 +2124,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing_ce"
-version = "0.28.5"
-source = "git+https://github.com/matter-labs/pairing.git?rev=d24f2c5871089c4cd4f54c0ca266bb9fef6115eb#d24f2c5871089c4cd4f54c0ca266bb9fef6115eb"
+version = "0.28.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843b5b6fb63f00460f611dbc87a50bbbb745f0dfe5cbf67ca89299c79098640e"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -3635,7 +3636,8 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vise"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=a5bb80c9ce7168663114ee30e794d6dc32159ee4#a5bb80c9ce7168663114ee30e794d6dc32159ee4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229baafe01d5177b63c6ee1def80d8e39a2365e64caf69ddb05a57594b15647c"
 dependencies = [
  "compile-fmt",
  "elsa",
@@ -3648,7 +3650,8 @@ dependencies = [
 [[package]]
 name = "vise-exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=a5bb80c9ce7168663114ee30e794d6dc32159ee4#a5bb80c9ce7168663114ee30e794d6dc32159ee4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23981b18d697026f5430249ab01ba739ef2edc463e400042394331cb2bb63494"
 dependencies = [
  "hyper 0.14.29",
  "once_cell",
@@ -3660,7 +3663,8 @@ dependencies = [
 [[package]]
 name = "vise-macros"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=a5bb80c9ce7168663114ee30e794d6dc32159ee4#a5bb80c9ce7168663114ee30e794d6dc32159ee4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb19c33cd5f04dcf4e767635e058a998edbc2b7fca32ade0a4a1cea0f8e9b34"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://matter-labs.io/"
 license = "MIT"
+version = "0.1.0"
 
 [workspace.dependencies]
 # Crates from this repo.
@@ -38,9 +39,9 @@ zksync_protobuf = { path = "libs/protobuf" }
 zksync_protobuf_build = { path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
-pairing = { package = "pairing_ce", git = "https://github.com/matter-labs/pairing.git", rev = "d24f2c5871089c4cd4f54c0ca266bb9fef6115eb" }
-vise = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "a5bb80c9ce7168663114ee30e794d6dc32159ee4" }
-vise-exporter = { version = "0.1.0", git = "https://github.com/matter-labs/vise.git", rev = "a5bb80c9ce7168663114ee30e794d6dc32159ee4" }
+pairing = { package = "pairing_ce", version = "=0.28.6" }
+vise = "0.1.0"
+vise-exporter = "0.1.0"
 
 # Crates from third-parties.
 anyhow = "1"

--- a/node/actors/bft/Cargo.toml
+++ b/node/actors/bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_bft"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/actors/executor/Cargo.toml
+++ b/node/actors/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_executor"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/actors/network/Cargo.toml
+++ b/node/actors/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_network"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/concurrency/Cargo.toml
+++ b/node/libs/concurrency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_concurrency"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/crypto/Cargo.toml
+++ b/node/libs/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_crypto"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/protobuf/Cargo.toml
+++ b/node/libs/protobuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_protobuf"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/protobuf_build/Cargo.toml
+++ b/node/libs/protobuf_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_protobuf_build"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/roles/Cargo.toml
+++ b/node/libs/roles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_roles"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/storage/Cargo.toml
+++ b/node/libs/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_storage"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/libs/utils/Cargo.toml
+++ b/node/libs/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_utils"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/tests/Cargo.toml
+++ b/node/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tester"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/tools/Cargo.toml
+++ b/node/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_consensus_tools"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## What ❔

- Changes git dependency on `pairing` to the published one.
- Same for `vise` and `vise-exporter`
- Uses `workspace.version` for all the crates.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
