### PR TITLE
feat: Batch vote publish loop (BFT-474)

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "tracing",
  "vise",
  "zksync_concurrency",
+ "zksync_consensus_crypto",
  "zksync_consensus_roles",
  "zksync_protobuf",
  "zksync_protobuf_build",

--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -22,7 +22,7 @@ pub(super) struct AttesterRunner {
 }
 
 impl AttesterRunner {
-    /// Crete a new instance of a runner.
+    /// Create a new instance of a runner.
     pub(super) fn new(
         block_store: Arc<BlockStore>,
         batch_store: Arc<BatchStore>,

--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -1,0 +1,73 @@
+//! Module to publish attestations over batches.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use zksync_concurrency::ctx;
+use zksync_concurrency::time;
+use zksync_consensus_network::gossip::BatchVotesPublisher;
+use zksync_consensus_storage::{BatchStore, BlockStore};
+
+use crate::Attester;
+
+const POLL_INTERVAL: time::Duration = time::Duration::seconds(1);
+
+/// Polls the database for new batches to be signed and publishes them to the gossip channel.
+pub(super) struct AttesterRunner {
+    block_store: Arc<BlockStore>,
+    batch_store: Arc<BatchStore>,
+    attester: Attester,
+    publisher: BatchVotesPublisher,
+}
+
+impl AttesterRunner {
+    /// Crete a new instance of a runner.
+    pub(super) fn new(
+        block_store: Arc<BlockStore>,
+        batch_store: Arc<BatchStore>,
+        attester: Attester,
+        publisher: BatchVotesPublisher,
+    ) -> Self {
+        Self {
+            block_store,
+            batch_store,
+            attester,
+            publisher,
+        }
+    }
+    /// Poll the database for new L1 batches and publish our signature over the batch.
+    pub(super) async fn run(self, ctx: &ctx::Ctx) -> ctx::Result<()> {
+        let public_key = self.attester.key.public();
+        loop {
+            // Pretend that the attesters can evolve.
+            let Some(attesters) = self.block_store.genesis().attesters.as_ref() else {
+                continue;
+            };
+            if !attesters.contains(&public_key) {
+                continue;
+            }
+
+            let unsigned_batch_numbers = self
+                .batch_store
+                .unsigned_batch_numbers(ctx)
+                .await
+                .context("unsigned_batch_numbers")?;
+
+            for bn in unsigned_batch_numbers {
+                if let Some(batch) = self
+                    .batch_store
+                    .batch_to_sign(ctx, bn)
+                    .await
+                    .context("batch_to_sign")?
+                {
+                    self.publisher
+                        .publish(attesters, &self.attester.key, batch)
+                        .await
+                        .context("publish")?;
+                }
+            }
+
+            ctx.sleep(POLL_INTERVAL).await?;
+        }
+    }
+}

--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use zksync_concurrency::ctx;
 use zksync_concurrency::time;
 use zksync_consensus_network::gossip::BatchVotesPublisher;
+use zksync_consensus_roles::attester::BatchNumber;
 use zksync_consensus_storage::{BatchStore, BlockStore};
 
 use crate::Attester;
@@ -38,6 +39,9 @@ impl AttesterRunner {
     /// Poll the database for new L1 batches and publish our signature over the batch.
     pub(super) async fn run(self, ctx: &ctx::Ctx) -> ctx::Result<()> {
         let public_key = self.attester.key.public();
+        // The first batch number we want to publish our vote for. We don't have to re-publish a vote
+        // because once it enters the vote register even future peers can pull it from there.
+        let mut min_batch_number = BatchNumber(0);
         loop {
             // Pretend that the attesters can evolve.
             let Some(attesters) = self.block_store.genesis().attesters.as_ref() else {
@@ -47,19 +51,31 @@ impl AttesterRunner {
                 continue;
             }
 
-            let unsigned_batch_numbers = self
+            let mut unsigned_batch_numbers = self
                 .batch_store
                 .unsigned_batch_numbers(ctx)
                 .await
                 .context("unsigned_batch_numbers")?;
 
+            // Just to be sure we go from smaller to higher batches.
+            unsigned_batch_numbers.sort();
+
             for bn in unsigned_batch_numbers {
+                // If we have already voted on this we can move on, no need to fetch the payload again.
+                // Batches appear in the store in order, even if we might have QC for a newer and not for an older batch,
+                // so once published our vote for a certain height, we can expect that we only have to vote on newer batches.
+                if bn < min_batch_number {
+                    continue;
+                }
+
                 if let Some(batch) = self
                     .batch_store
                     .batch_to_sign(ctx, bn)
                     .await
                     .context("batch_to_sign")?
                 {
+                    min_batch_number = batch.number.next();
+
                     self.publisher
                         .publish(attesters, &self.attester.key, batch)
                         .await

--- a/node/libs/roles/src/attester/messages/batch.rs
+++ b/node/libs/roles/src/attester/messages/batch.rs
@@ -8,6 +8,11 @@ use zksync_consensus_crypto::{keccak256::Keccak256, ByteFmt, Text, TextFmt};
 use zksync_consensus_utils::enum_util::Variant;
 
 /// A batch of L2 blocks used for the peers to fetch and keep in sync.
+///
+/// The use case for this is for peers to be able to catch up with L1
+/// batches they missed during periods of being offline. These will
+/// come with a proof of having been included on L1, rather than an
+/// attester quorum certificate.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct SyncBatch {
     /// The number of the batch.
@@ -15,6 +20,9 @@ pub struct SyncBatch {
     /// The payloads of the blocks the batch contains.
     pub payloads: Vec<Payload>,
     /// The proof of the batch.
+    ///
+    /// It is going to be a Merkle proof the the batch has been included
+    /// in the state hash of the L1.
     pub proof: Vec<u8>,
 }
 

--- a/node/libs/storage/Cargo.toml
+++ b/node/libs/storage/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 [dependencies]
 zksync_concurrency.workspace = true
 zksync_consensus_roles.workspace = true
+zksync_consensus_crypto.workspace = true
 zksync_protobuf.workspace = true
 
 anyhow.workspace = true

--- a/node/libs/storage/src/batch_store.rs
+++ b/node/libs/storage/src/batch_store.rs
@@ -234,6 +234,26 @@ impl BatchStore {
         Ok(batch)
     }
 
+    /// Retrieve the number of all batches that don't have a QC yet and potentially need to be signed.
+    ///
+    /// It returns only the numbers which follow the last finalized batch, that is, there might be batches
+    /// before the earliest in these numbers that isn't signed, but it would be futile to sign them any more.
+    pub async fn unsigned_batch_numbers(
+        &self,
+        _ctx: &ctx::Ctx,
+    ) -> ctx::Result<Vec<attester::BatchNumber>> {
+        todo!("retrieve unsigned numbers from persistent store")
+    }
+
+    /// Retrieve a batch to be signed.
+    pub async fn batch_to_sign(
+        &self,
+        _ctx: &ctx::Ctx,
+        _number: attester::BatchNumber,
+    ) -> ctx::Result<Option<attester::Batch>> {
+        todo!("retrieve the batch commitment from persistent store")
+    }
+
     /// Append batch to a queue to be persisted eventually.
     /// Since persisting a batch may take a significant amount of time,
     /// BatchStore contains a queue of batches waiting to be persisted.

--- a/node/libs/storage/src/batch_store.rs
+++ b/node/libs/storage/src/batch_store.rs
@@ -56,17 +56,41 @@ pub trait PersistentBatchStore: 'static + fmt::Debug + Send + Sync {
     /// Returns `None` if no batches have been created yet.
     async fn last_batch(&self, ctx: &ctx::Ctx) -> ctx::Result<Option<attester::BatchNumber>>;
 
+    /// Get the numbers of L1 batches which are missing the corresponding L1 batch quorum certificates
+    /// and potentially need to be signed by attesters.
+    ///
+    /// A replica might never have a complete history of L1 batch QCs; once the L1 batch is included on L1,
+    /// the replicas might use the [attester::SyncBatch] route to obtain them, in which case they will not
+    /// have a QC and no reason to get them either. The store will have sufficient information to decide
+    /// where it's still necessary to gossip votes; for example the main node will want to have a QC on
+    /// every batch while it's the one submitting them to L1, while replicas can ask the L1 what is considered
+    /// final.
+    async fn unsigned_batch_numbers(
+        &self,
+        ctx: &ctx::Ctx,
+    ) -> ctx::Result<Vec<attester::BatchNumber>>;
+
     /// Get the L1 batch QC from storage with the highest number.
     ///
     /// Returns `None` if we don't have a QC for any of the batches yet.
     async fn last_batch_qc(&self, ctx: &ctx::Ctx) -> ctx::Result<Option<attester::BatchQC>>;
 
-    /// Returns the batch with the given number.
+    /// Returns the [attester::SyncBatch] with the given number, which is used by peers
+    /// to catch up with L1 batches that they might have missed if they went offline.
     async fn get_batch(
         &self,
         ctx: &ctx::Ctx,
         number: attester::BatchNumber,
     ) -> ctx::Result<Option<attester::SyncBatch>>;
+
+    /// Returns the [attester::Batch] with the given number, which is the `message` that
+    /// appears in [attester::BatchQC], and represents the content that needs to be signed
+    /// by the attesters.
+    async fn get_batch_to_sign(
+        &self,
+        ctx: &ctx::Ctx,
+        number: attester::BatchNumber,
+    ) -> ctx::Result<Option<attester::Batch>>;
 
     /// Returns the QC of the batch with the given number.
     async fn get_batch_qc(
@@ -240,18 +264,28 @@ impl BatchStore {
     /// before the earliest in these numbers that isn't signed, but it would be futile to sign them any more.
     pub async fn unsigned_batch_numbers(
         &self,
-        _ctx: &ctx::Ctx,
+        ctx: &ctx::Ctx,
     ) -> ctx::Result<Vec<attester::BatchNumber>> {
-        todo!("retrieve unsigned numbers from persistent store")
+        let unsigned = self
+            .persistent
+            .unsigned_batch_numbers(ctx)
+            .await
+            .context("persistent.get_batch_to_sign()")?;
+        Ok(unsigned)
     }
 
     /// Retrieve a batch to be signed.
     pub async fn batch_to_sign(
         &self,
-        _ctx: &ctx::Ctx,
-        _number: attester::BatchNumber,
+        ctx: &ctx::Ctx,
+        number: attester::BatchNumber,
     ) -> ctx::Result<Option<attester::Batch>> {
-        todo!("retrieve the batch commitment from persistent store")
+        let batch = self
+            .persistent
+            .get_batch_to_sign(ctx, number)
+            .await
+            .context("persistent.get_batch_to_sign()")?;
+        Ok(batch)
     }
 
     /// Append batch to a queue to be persisted eventually.

--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -22,8 +22,7 @@ struct BlockStoreInner {
 struct BatchStoreInner {
     persisted: sync::watch::Sender<BatchStoreState>,
     batches: Mutex<VecDeque<attester::SyncBatch>>,
-    // This field was only added to be able to implement the PersistentBatchStore trait correctly.
-    qcs: Mutex<HashMap<attester::BatchNumber, attester::BatchQC>>,
+    certs: Mutex<HashMap<attester::BatchNumber, attester::BatchQC>>,
 }
 
 /// In-memory block store.
@@ -74,7 +73,7 @@ impl BatchStore {
         Self(Arc::new(BatchStoreInner {
             persisted: sync::watch::channel(BatchStoreState { first, last: None }).0,
             batches: Mutex::default(),
-            qcs: Mutex::default(),
+            certs: Mutex::default(),
         }))
     }
 }
@@ -137,9 +136,43 @@ impl PersistentBatchStore for BatchStore {
     }
 
     async fn last_batch_qc(&self, _ctx: &ctx::Ctx) -> ctx::Result<Option<attester::BatchQC>> {
-        let qcs = self.0.qcs.lock().unwrap();
-        let last_batch_number = qcs.keys().max().unwrap();
-        Ok(qcs.get(last_batch_number).cloned())
+        let certs = self.0.certs.lock().unwrap();
+        let last_batch_number = certs.keys().max().unwrap();
+        Ok(certs.get(last_batch_number).cloned())
+    }
+
+    async fn unsigned_batch_numbers(
+        &self,
+        _ctx: &ctx::Ctx,
+    ) -> ctx::Result<Vec<attester::BatchNumber>> {
+        let batches = self.0.batches.lock().unwrap();
+        let certs = self.0.certs.lock().unwrap();
+
+        Ok(batches
+            .iter()
+            .map(|b| b.number)
+            .filter(|n| !certs.contains_key(n))
+            .collect())
+    }
+
+    async fn get_batch_to_sign(
+        &self,
+        ctx: &ctx::Ctx,
+        number: attester::BatchNumber,
+    ) -> ctx::Result<Option<attester::Batch>> {
+        // Here we just produce some deterministic mock hash. The real hash is available in the database.
+        // and contains a commitment to the data submitted to L1. It is *not* over SyncBatch.
+        let Some(batch) = self.get_batch(ctx, number).await? else {
+            return Ok(None);
+        };
+
+        let bz = zksync_protobuf::canonical(&batch);
+        let hash = zksync_consensus_crypto::keccak256::Keccak256::new(&bz);
+
+        Ok(Some(attester::Batch {
+            number,
+            hash: attester::BatchHash(hash),
+        }))
     }
 
     async fn get_batch_qc(
@@ -147,12 +180,12 @@ impl PersistentBatchStore for BatchStore {
         _ctx: &ctx::Ctx,
         number: attester::BatchNumber,
     ) -> ctx::Result<Option<attester::BatchQC>> {
-        let qcs = self.0.qcs.lock().unwrap();
-        Ok(qcs.get(&number).cloned())
+        let certs = self.0.certs.lock().unwrap();
+        Ok(certs.get(&number).cloned())
     }
 
     async fn store_qc(&self, _ctx: &ctx::Ctx, qc: attester::BatchQC) -> ctx::Result<()> {
-        self.0.qcs.lock().unwrap().insert(qc.message.number, qc);
+        self.0.certs.lock().unwrap().insert(qc.message.number, qc);
         Ok(())
     }
 


### PR DESCRIPTION
## What ❔

- [x] Add `BatchStore::unsigned_batch_numbers` to query `BatchNumber`s that still need a QC
- [x] Add `BatchStore::batch_to_sign` to fetch the `Batch` with the correct `BatchHash` that needs to be signed
- [x] Add `PersistentBatchStore::unsigned_batch_numbers` to implement the above
- [x] Add `PersistentBatchStore::batch_to_sign` to implement the above
- [x] Add `AttesterRunner` to periodically query `unsigned_batch_numbers`, retrieve the data with `batch_to_sign` and publish the `Signed<Batch>` to the gossip network.
- [x] Run the `AttesterRunner` in `Executor` if the node has an `Attester` key.
- [x] Add a minimum batch number to sign to prevent repeated signing

The code will re-submit the node's signature after a restart to a number of batches to be determined by the database query. We can say we'll re-publish the top 10 unsigned batches, or we can say we'll only look for the ones which follow the last finalised batch observed the Main node. It is enough to publish a vote once because of the way `BatchVotes` works (gossip peers will pull the data they need when they connect). Because we'll always have the batches in order, we can take note of the highest number we have published a vote for and never publish it again (until a restart), to save ourselves the trouble of repeatedly retrieving and signing the payload. That said it is assumed that `batch_to_sign` is cheap as it just needs to look up a hash in the DB.

### Follow up steps

The ticket will need a counterpart in `zksync-era` to implement the new `PersistentBatchStore` operations by querying Postgres. Need figuring out which column needs to go into the hash.

## Why ❔

To publish the attestations over L1 batches to the gossip network, so that a QC can be formed in https://github.com/matter-labs/era-consensus/pull/145

