### PR TITLE
chore: Misc preparations for publishing

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "tester"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_bft"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "blst",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_executor"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_network"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_storage"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_tools"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "heck",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,24 +19,26 @@ resolver = "2"
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://matter-labs.io/"
-license = "MIT"
-version = "0.1.0"
+repository = "https://github.com/matter-labs/era-consensus"
+license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+version = "0.1.0-rc.1"
 
 [workspace.dependencies]
 # Crates from this repo.
-zksync_consensus_bft = { path = "actors/bft" }
-zksync_consensus_crypto = { path = "libs/crypto" }
-zksync_consensus_executor = { path = "actors/executor" }
-zksync_consensus_network = { path = "actors/network" }
-zksync_consensus_roles = { path = "libs/roles" }
-zksync_consensus_storage = { path = "libs/storage" }
-zksync_consensus_tools = { path = "tools" }
-zksync_consensus_utils = { path = "libs/utils" }
+zksync_consensus_bft = { version = "=0.1.0-rc.1", path = "actors/bft" }
+zksync_consensus_crypto = { version = "=0.1.0-rc.1", path = "libs/crypto" }
+zksync_consensus_executor = { version = "=0.1.0-rc.1", path = "actors/executor" }
+zksync_consensus_network = { version = "=0.1.0-rc.1", path = "actors/network" }
+zksync_consensus_roles = { version = "=0.1.0-rc.1", path = "libs/roles" }
+zksync_consensus_storage = { version = "=0.1.0-rc.1", path = "libs/storage" }
+zksync_consensus_tools = { version = "=0.1.0-rc.1", path = "tools" }
+zksync_consensus_utils = { version = "=0.1.0-rc.1", path = "libs/utils" }
 
 # Crates from this repo that might become independent in the future.
-zksync_concurrency = { path = "libs/concurrency" }
-zksync_protobuf = { path = "libs/protobuf" }
-zksync_protobuf_build = { path = "libs/protobuf_build" }
+zksync_concurrency = { version = "=0.1.0-rc.1", path = "libs/concurrency" }
+zksync_protobuf = { version = "=0.1.0-rc.1", path = "libs/protobuf" }
+zksync_protobuf_build = { version = "=0.1.0-rc.1", path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
 pairing = { package = "pairing_ce", version = "=0.28.6" }

--- a/node/actors/bft/Cargo.toml
+++ b/node/actors/bft/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/actors/executor/Cargo.toml
+++ b/node/actors/executor/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/actors/network/Cargo.toml
+++ b/node/actors/network/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/libs/concurrency/Cargo.toml
+++ b/node/libs/concurrency/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/crypto/Cargo.toml
+++ b/node/libs/crypto/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/protobuf/Cargo.toml
+++ b/node/libs/protobuf/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 links = "zksync_protobuf_proto"
 
 [dependencies]

--- a/node/libs/protobuf_build/Cargo.toml
+++ b/node/libs/protobuf_build/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/roles/Cargo.toml
+++ b/node/libs/roles/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 links = "zksync_consensus_roles_proto"
 
 [dependencies]

--- a/node/libs/storage/Cargo.toml
+++ b/node/libs/storage/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/libs/utils/Cargo.toml
+++ b/node/libs/utils/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/tests/Cargo.toml
+++ b/node/tests/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+publish = false
 
 [dependencies]
 zksync_consensus_tools.workspace = true

--- a/node/tools/Cargo.toml
+++ b/node/tools/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords.workspace = true
 default-run = "executor"
 
 [dependencies]


### PR DESCRIPTION
## What ❔

- Changes version to `0.1.0-rc.1` since the codebase is under heavy changes and is not in production yet; will prevent us from premature version bumps until consensus is on mainnet.
- Sets other required fields for publishing.
- Marks tests as `publish=false`.

## Why ❔

Preparations for publishing on crates.io.