### PR TITLE
Prepare 0.1.0-rc.1 release

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -205,6 +205,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +309,29 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.66",
+ "which",
 ]
 
 [[package]]
@@ -542,6 +592,15 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -821,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1071,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1343,11 +1414,11 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "log",
- "rustls 0.23.10",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1599,7 +1670,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.10",
+ "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -1723,7 +1794,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.10",
+ "rustls",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -1829,7 +1900,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -2005,6 +2076,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2240,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peeking_take_while"
@@ -2744,24 +2827,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2811,7 +2881,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.10",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
@@ -2833,6 +2903,7 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3331,15 +3402,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce110c38c3c9b6e5cc4fe72e60feb5b327750388a10a276e3d5d7d431e3dc76c"
+checksum = "83a296135fdab7b3a1f708c338c50bab570bcd77d44080cde9341df45c0c6d73"
 dependencies = [
  "futures-util",
  "pin-project-lite",
  "thiserror",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3374,22 +3445,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3770,6 +3830,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,7 +4166,7 @@ dependencies = [
  "thiserror",
  "tls-listener",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tracing",
  "vise",
  "zksync_concurrency",
@@ -4166,7 +4238,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -90,7 +90,7 @@ test-casing = "0.1.0"
 thiserror = "1.0.40"
 time = "0.3.23"
 tokio = { version = "1.34.0", features = ["full"] }
-tokio-rustls = "0.25.0"
+tokio-rustls = "0.26.0"
 tower = { version = "0.4.13" }
 tracing = { version = "0.1.37", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
@@ -98,7 +98,7 @@ zeroize = { version = "1.7.0", features = ["zeroize_derive"] }
 hyper = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
-tls-listener = { version = "0.10.0", features = ["rustls"]}
+tls-listener = { version = "0.10.1", features = ["rustls"]}
 rustls-pemfile = "2"
 base64 = "0.22.1"
 build_html = "2.4.0"

--- a/node/actors/bft/Cargo.toml
+++ b/node/actors/bft/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus bft actor"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/actors/executor/Cargo.toml
+++ b/node/actors/executor/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus executor actor"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/actors/network/Cargo.toml
+++ b/node/actors/network/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus network actor"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/deny.toml
+++ b/node/deny.toml
@@ -33,6 +33,7 @@ allow = [
     # Permissive licenses
     "Apache-2.0",
     "BSD-3-Clause",
+    "OpenSSL",
     "ISC",
     "MIT",
     "Unicode-DFS-2016",

--- a/node/libs/concurrency/Cargo.toml
+++ b/node/libs/concurrency/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "Structured concurrency framework"
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/crypto/Cargo.toml
+++ b/node/libs/crypto/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus cryptographic utilities"
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/protobuf/Cargo.toml
+++ b/node/libs/protobuf/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 links = "zksync_protobuf_proto"
+description = "ZKsync consensus protobuf types and utilities"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/libs/protobuf_build/Cargo.toml
+++ b/node/libs/protobuf_build/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus protobuf codegen"
 
 [dependencies]
 anyhow.workspace = true

--- a/node/libs/roles/Cargo.toml
+++ b/node/libs/roles/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 links = "zksync_consensus_roles_proto"
+description = "ZKsync consensus node role types"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/libs/storage/Cargo.toml
+++ b/node/libs/storage/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus storage"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/libs/utils/Cargo.toml
+++ b/node/libs/utils/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords.workspace = true
+description = "ZKsync consensus utilities"
 
 [dependencies]
 zksync_concurrency.workspace = true

--- a/node/tools/Cargo.toml
+++ b/node/tools/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 default-run = "executor"
+description = "ZKsync consensus tools"
 
 [dependencies]
 zksync_concurrency.workspace = true


### PR DESCRIPTION
## What ❔

Prepares the first release for consensus codebase (already on crates.io)
I had to bump `tls-listener` and `tokio-rustls`, because otherwise network actor won't compile outside of workspace.

## Why ❔

Publishing crates on crates.io