### PR TITLE
CHORE: Update version to 0.1.0-rc.2

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "tester"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_bft"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "blst",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_executor"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_network"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_storage"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_tools"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "heck",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,23 +22,23 @@ homepage = "https://matter-labs.io/"
 repository = "https://github.com/matter-labs/era-consensus"
 license = "MIT OR Apache-2.0"
 keywords = ["blockchain", "zksync"]
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 
 [workspace.dependencies]
 # Crates from this repo.
-zksync_consensus_bft = { version = "=0.1.0-rc.1", path = "actors/bft" }
-zksync_consensus_crypto = { version = "=0.1.0-rc.1", path = "libs/crypto" }
-zksync_consensus_executor = { version = "=0.1.0-rc.1", path = "actors/executor" }
-zksync_consensus_network = { version = "=0.1.0-rc.1", path = "actors/network" }
-zksync_consensus_roles = { version = "=0.1.0-rc.1", path = "libs/roles" }
-zksync_consensus_storage = { version = "=0.1.0-rc.1", path = "libs/storage" }
-zksync_consensus_tools = { version = "=0.1.0-rc.1", path = "tools" }
-zksync_consensus_utils = { version = "=0.1.0-rc.1", path = "libs/utils" }
+zksync_consensus_bft = { version = "=0.1.0-rc.2", path = "actors/bft" }
+zksync_consensus_crypto = { version = "=0.1.0-rc.2", path = "libs/crypto" }
+zksync_consensus_executor = { version = "=0.1.0-rc.2", path = "actors/executor" }
+zksync_consensus_network = { version = "=0.1.0-rc.2", path = "actors/network" }
+zksync_consensus_roles = { version = "=0.1.0-rc.2", path = "libs/roles" }
+zksync_consensus_storage = { version = "=0.1.0-rc.2", path = "libs/storage" }
+zksync_consensus_tools = { version = "=0.1.0-rc.2", path = "tools" }
+zksync_consensus_utils = { version = "=0.1.0-rc.2", path = "libs/utils" }
 
 # Crates from this repo that might become independent in the future.
-zksync_concurrency = { version = "=0.1.0-rc.1", path = "libs/concurrency" }
-zksync_protobuf = { version = "=0.1.0-rc.1", path = "libs/protobuf" }
-zksync_protobuf_build = { version = "=0.1.0-rc.1", path = "libs/protobuf_build" }
+zksync_concurrency = { version = "=0.1.0-rc.2", path = "libs/concurrency" }
+zksync_protobuf = { version = "=0.1.0-rc.2", path = "libs/protobuf" }
+zksync_protobuf_build = { version = "=0.1.0-rc.2", path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
 pairing = { package = "pairing_ce", version = "=0.28.6" }
@@ -98,7 +98,7 @@ zeroize = { version = "1.7.0", features = ["zeroize_derive"] }
 hyper = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
-tls-listener = { version = "0.10.1", features = ["rustls"]}
+tls-listener = { version = "0.10.1", features = ["rustls"] }
 rustls-pemfile = "2"
 base64 = "0.22.1"
 build_html = "2.4.0"


### PR DESCRIPTION
## What ❔

Bumps the version to 0.1.0-rc.2

## Why ❔

So that we can merge https://github.com/matter-labs/zksync-era/pull/2399 and https://github.com/matter-labs/zksync-era/pull/2410