### PR TITLE
fix: Comments about SyncBatch vs L1 and wait for batch persisted (BFT-474)

### DIFF
--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -52,9 +52,11 @@ impl AttesterRunner {
         // Find the initial range of batches that we want to (re)sign after a (re)start.
         let last_batch_number = self
             .batch_store
-            .last_batch_number(ctx)
+            .wait_until_persisted(ctx, attester::BatchNumber(0))
             .await
-            .context("last_batch_number")?
+            .context("wait_until_persisted")?
+            .last
+            .map(|b| b.number)
             .unwrap_or_default();
 
         // Determine the batch to start signing from.

--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -86,6 +86,14 @@ impl AttesterRunner {
                 .context("publish")?;
 
             batch_number = batch_number.next();
+
+            // We can avoid actively polling the database by waiting for the next persisted batch to appear
+            // in the memory (which itself relies on polling). This happens once we have the commitment,
+            // which for nodes that get the blocks through BFT should happen after execution. Nodes which
+            // rely on batch sync don't participate in attestations as they need the batch on L1 first.
+            self.batch_store
+                .wait_until_persisted(ctx, batch_number)
+                .await?;
         }
     }
 

--- a/node/libs/roles/src/attester/messages/batch.rs
+++ b/node/libs/roles/src/attester/messages/batch.rs
@@ -22,7 +22,10 @@ pub struct SyncBatch {
     /// The proof of the batch.
     ///
     /// It is going to be a Merkle proof the the batch has been included
-    /// in the state hash of the L1.
+    /// in the state of the L1 system contract (not the L1 state root hash).
+    /// It can be produced as soon as we have the commitment available
+    /// locally, but validation requires a trusted L1 client to look up
+    /// the system contract state.
     pub proof: Vec<u8>,
 }
 


### PR DESCRIPTION
## What ❔

* Fixes the comments I made about `SyncBatch::proof` requiring L1 inclusion - that was based on a misunderstanding that the `proof` was a Merkle proof starting from the L1 state root hash, rather than a field inside the zksync system contract on L1. We only need an L1 client to validate the proof, but we can produce it offline as soon as we have the commitment locally.
* Changed the loop in `AttesterRunner` so that it waits for `persisted` state of the `BatchStore` to indicate that the next batch number is available. This will be when the `SyncBatch` can be constructed, so it's when the commitment is ready too (or will be, not currently) and we're ready to sign the payload. 
* Removed `BatchStore::last_batch_number`; I wanted to use `persisted.last`, which can be `None` in the beginning until `SyncBatch::proof` is available, with a fallback to `PersistentBatchStore::last_batch` which just looks at the latest `l1_batches` record, but I wasn't sure whether a next batch can be created before the commitment for the previous one is available, which would cause a regression in the value returned. Instead we just use `BatchStore::wait_for_persisted(0)` to tell us what the starting value is after the first batch is ready.

## Why ❔

To remove misleading comments, and to reduce unneeded polling of the database itself - now we wait until the memory indicates it's worth hitting the DB.