### PR TITLE
DEBUG: Log if the node is not an attester

### DIFF
--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -155,6 +155,8 @@ impl Executor {
                     runner.run(ctx).await?;
                     Ok(())
                 });
+            } else {
+                tracing::info!("Running the node in non-attester mode.");
             }
 
             if let Some(debug_config) = self.config.debug_page {


### PR DESCRIPTION
## What ❔

Adds more logging around attestations. 

## Why ❔

For some reason on stage2 the main node doesn't seem to have the attester key, even though it's in the config.