### PR TITLE
feat: Poll the main node for batch to vote on (BFT-496)

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -4127,6 +4127,7 @@ name = "zksync_consensus_executor"
 version = "0.1.0-rc.4"
 dependencies = [
  "anyhow",
+ "async-trait",
  "rand 0.8.5",
  "test-casing",
  "tokio",

--- a/node/actors/bft/src/testonly/run.rs
+++ b/node/actors/bft/src/testonly/run.rs
@@ -14,7 +14,7 @@ use zksync_concurrency::{
     },
     oneshot, scope,
 };
-use zksync_consensus_network as network;
+use zksync_consensus_network::{self as network};
 use zksync_consensus_roles::validator;
 use zksync_consensus_storage::{testonly::TestMemoryStorage, BlockStore};
 use zksync_consensus_utils::pipe;
@@ -135,9 +135,11 @@ impl Test {
             for (i, net) in nets.into_iter().enumerate() {
                 let store = TestMemoryStorage::new(ctx, genesis).await;
                 s.spawn_bg(async { Ok(store.runner.run(ctx).await?) });
+
                 if self.nodes[i].0 == Behavior::Honest {
                     honest.push(store.blocks.clone());
                 }
+
                 nodes.push(Node {
                     net,
                     behavior: self.nodes[i].0,

--- a/node/actors/executor/Cargo.toml
+++ b/node/actors/executor/Cargo.toml
@@ -20,6 +20,7 @@ zksync_consensus_utils.workspace = true
 zksync_protobuf.workspace = true
 
 anyhow.workspace = true
+async-trait.workspace = true
 rand.workspace = true
 tracing.workspace = true
 vise.workspace = true

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -152,7 +152,7 @@ impl Executor {
                     self.batch_store.clone(),
                     attester,
                     net.batch_vote_publisher(),
-                    net.attestation_status_receiver(),
+                    self.attestation_status.subscribe(),
                 );
                 s.spawn(async {
                     runner.run(ctx).await?;

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -15,7 +15,7 @@ use zksync_consensus_storage::{BatchStore, BlockStore, ReplicaStore};
 use zksync_consensus_utils::pipe;
 use zksync_protobuf::kB;
 
-mod attestation;
+pub mod attestation;
 mod io;
 #[cfg(test)]
 mod tests;
@@ -153,6 +153,7 @@ impl Executor {
                     attester,
                     net.batch_vote_publisher(),
                     self.attestation_status.subscribe(),
+                    time::Duration::seconds(1), // TODO: Move to config?
                 );
                 s.spawn(async {
                     runner.run(ctx).await?;

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use zksync_concurrency::{ctx, limiter, net, scope, time};
 use zksync_consensus_bft as bft;
-use zksync_consensus_network as network;
+use zksync_consensus_network::{self as network, gossip::AttestationStatusClient};
 use zksync_consensus_roles::{attester, node, validator};
 use zksync_consensus_storage::{BatchStore, BlockStore, ReplicaStore};
 use zksync_consensus_utils::pipe;
@@ -97,6 +97,8 @@ pub struct Executor {
     pub validator: Option<Validator>,
     /// Validator-specific node data.
     pub attester: Option<Attester>,
+    /// Client to use to poll attestation status: either through the main node API or the DB.
+    pub attestation_status_client: Box<dyn AttestationStatusClient>,
 }
 
 impl Executor {
@@ -138,6 +140,7 @@ impl Executor {
                 self.block_store.clone(),
                 self.batch_store.clone(),
                 network_actor_pipe,
+                self.attestation_status_client,
             );
             net.register_metrics();
             s.spawn(async { runner.run(ctx).await.context("Network stopped") });
@@ -149,6 +152,7 @@ impl Executor {
                     self.batch_store.clone(),
                     attester,
                     net.batch_vote_publisher(),
+                    net.attestation_status_receiver(),
                 );
                 s.spawn(async {
                     runner.run(ctx).await?;

--- a/node/actors/executor/src/lib.rs
+++ b/node/actors/executor/src/lib.rs
@@ -70,6 +70,9 @@ pub struct Config {
     /// Http debug page configuration.
     /// If None, debug page is disabled
     pub debug_page: Option<http::DebugPageConfig>,
+
+    /// How often to poll the database looking for the batch commitment.
+    pub batch_poll_interval: time::Duration,
 }
 
 impl Config {
@@ -153,7 +156,7 @@ impl Executor {
                     attester,
                     net.batch_vote_publisher(),
                     self.attestation_status.subscribe(),
-                    time::Duration::seconds(1), // TODO: Move to config?
+                    self.config.batch_poll_interval,
                 );
                 s.spawn(async {
                     runner.run(ctx).await?;

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -23,6 +23,7 @@ fn config(cfg: &network::Config) -> Config {
         gossip_static_outbound: cfg.gossip.static_outbound.clone(),
         rpc: cfg.rpc.clone(),
         debug_page: None,
+        batch_poll_interval: time::Duration::seconds(1),
     }
 }
 

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -4,10 +4,7 @@ use rand::Rng as _;
 use tracing::Instrument as _;
 use zksync_concurrency::testonly::abort_on_panic;
 use zksync_consensus_bft as bft;
-use zksync_consensus_network::{
-    gossip::LocalAttestationStatus,
-    testonly::{new_configs, new_fullnode},
-};
+use zksync_consensus_network::testonly::{new_configs, new_fullnode};
 use zksync_consensus_roles::validator::{testonly::Setup, BlockNumber};
 use zksync_consensus_storage::{
     testonly::{in_memory, TestMemoryStorage},
@@ -29,12 +26,10 @@ fn config(cfg: &network::Config) -> Config {
     }
 }
 
-/// The test executors below are not running with attesters, so it doesn't matter if the clients
-/// are returning views based on the store of main node or each to their own. For simplicity this
-/// returns an implementation that queries the local store of each instance. Alternatively we  
-/// could implement an instance that never queries anything.
-fn mk_attestation_status_client(batch_store: &Arc<BatchStore>) -> impl AttestationStatusClient {
-    LocalAttestationStatus::new(batch_store.clone())
+/// The test executors below are not running with attesters, so we just create an [AttestationStatusWatch]
+/// that will never be updated.
+fn never_attest() -> Arc<AttestationStatusWatch> {
+    Arc::new(AttestationStatusWatch::default())
 }
 
 fn validator(
@@ -43,7 +38,6 @@ fn validator(
     batch_store: Arc<BatchStore>,
     replica_store: impl ReplicaStore,
 ) -> Executor {
-    let attestation_status_client = Box::new(mk_attestation_status_client(&batch_store));
     Executor {
         config: config(cfg),
         block_store,
@@ -54,7 +48,7 @@ fn validator(
             payload_manager: Box::new(bft::testonly::RandomPayload(1000)),
         }),
         attester: None,
-        attestation_status_client,
+        attestation_status: never_attest(),
     }
 }
 
@@ -63,14 +57,13 @@ fn fullnode(
     block_store: Arc<BlockStore>,
     batch_store: Arc<BatchStore>,
 ) -> Executor {
-    let attestation_status_client = Box::new(mk_attestation_status_client(&batch_store));
     Executor {
         config: config(cfg),
         block_store,
         batch_store,
         validator: None,
         attester: None,
-        attestation_status_client,
+        attestation_status: never_attest(),
     }
 }
 

--- a/node/actors/network/src/consensus/tests.rs
+++ b/node/actors/network/src/consensus/tests.rs
@@ -256,9 +256,11 @@ async fn test_address_change() {
         // should get reconstructed.
         cfgs[0].server_addr = net::tcp::testonly::reserve_listener();
         cfgs[0].public_addr = (*cfgs[0].server_addr).into();
+
         let (node0, runner) =
             testonly::Instance::new(cfgs[0].clone(), store.blocks.clone(), store.batches.clone());
         s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("node0")));
+
         nodes[0] = node0;
         for n in &nodes {
             n.wait_for_consensus_connections().await;

--- a/node/actors/network/src/gossip/attestation_status.rs
+++ b/node/actors/network/src/gossip/attestation_status.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+
+use zksync_concurrency::{ctx, sync};
+use zksync_consensus_roles::attester;
+use zksync_consensus_storage::BatchStore;
+
+use crate::watch::Watch;
+
+/// An interface which is used by attesters and nodes collecting votes over gossip to determine
+/// which is the next batch they are all supposed to be voting on, according to the main node.
+#[async_trait::async_trait]
+pub trait AttestationStatusClient: 'static + std::fmt::Debug + Send + Sync {
+    /// Get the next batch number for which the main node expects a batch QC to be formed.
+    ///
+    /// The API might return an error while genesis is being created, which we represent with `None`
+    /// here and mean that we'll have to try again later.
+    async fn next_batch_to_attest(
+        &self,
+        ctx: &ctx::Ctx,
+    ) -> ctx::Result<Option<attester::BatchNumber>>;
+}
+
+/// Implement the attestation status for the main node by returning the next to vote on from the [BatchStore].
+#[derive(Debug, Clone)]
+pub struct LocalAttestationStatus(Arc<BatchStore>);
+
+impl LocalAttestationStatus {
+    /// Create local attestation client form a [BatchStore].
+    pub fn new(store: Arc<BatchStore>) -> Self {
+        Self(store)
+    }
+}
+
+#[async_trait::async_trait]
+impl AttestationStatusClient for LocalAttestationStatus {
+    async fn next_batch_to_attest(
+        &self,
+        ctx: &ctx::Ctx,
+    ) -> ctx::Result<Option<attester::BatchNumber>> {
+        self.0.next_batch_to_attest(ctx).await
+    }
+}
+
+/// Coordinate the attestation by showing the status as seen by the main node.
+pub struct AttestationStatus {
+    /// Next batch number where voting is expected.
+    ///
+    /// Its value is `None` until the background process polling the main node
+    /// can establish a value to start from.
+    pub next_batch_to_attest: Option<attester::BatchNumber>,
+}
+
+/// The subscription over the attestation status which votes can monitor for change.
+pub type AttestationStatusReceiver = sync::watch::Receiver<AttestationStatus>;
+
+/// A [Watch] over an [AttestationStatus] which we can use to notify components about
+/// changes in the batch number the main node expects attesters to vote on.
+pub(crate) struct AttestationStatusWatch(Watch<AttestationStatus>);
+
+impl Default for AttestationStatusWatch {
+    fn default() -> Self {
+        Self(Watch::new(AttestationStatus {
+            next_batch_to_attest: None,
+        }))
+    }
+}
+
+impl AttestationStatusWatch {
+    /// Subscribes to AttestationStatus updates.
+    pub(crate) fn subscribe(&self) -> AttestationStatusReceiver {
+        self.0.subscribe()
+    }
+
+    /// Set the next batch number to attest on and notify subscribers it changed.
+    pub(crate) async fn update(&self, next_batch_to_attest: attester::BatchNumber) {
+        let this = self.0.lock().await;
+        this.send_if_modified(|status| {
+            if status.next_batch_to_attest == Some(next_batch_to_attest) {
+                return false;
+            }
+            status.next_batch_to_attest = Some(next_batch_to_attest);
+            true
+        });
+    }
+}

--- a/node/actors/network/src/gossip/attestation_status.rs
+++ b/node/actors/network/src/gossip/attestation_status.rs
@@ -1,6 +1,7 @@
+use std::fmt;
 use std::sync::Arc;
 
-use zksync_concurrency::{ctx, sync};
+use zksync_concurrency::{ctx, sync, time};
 use zksync_consensus_roles::attester;
 use zksync_consensus_storage::BatchStore;
 
@@ -9,7 +10,7 @@ use crate::watch::Watch;
 /// An interface which is used by attesters and nodes collecting votes over gossip to determine
 /// which is the next batch they are all supposed to be voting on, according to the main node.
 #[async_trait::async_trait]
-pub trait AttestationStatusClient: 'static + std::fmt::Debug + Send + Sync {
+pub trait AttestationStatusClient: 'static + fmt::Debug + Send + Sync {
     /// Get the next batch number for which the main node expects a batch QC to be formed.
     ///
     /// The API might return an error while genesis is being created, which we represent with `None`
@@ -20,28 +21,8 @@ pub trait AttestationStatusClient: 'static + std::fmt::Debug + Send + Sync {
     ) -> ctx::Result<Option<attester::BatchNumber>>;
 }
 
-/// Implement the attestation status for the main node by returning the next to vote on from the [BatchStore].
-#[derive(Debug, Clone)]
-pub struct LocalAttestationStatus(Arc<BatchStore>);
-
-impl LocalAttestationStatus {
-    /// Create local attestation client form a [BatchStore].
-    pub fn new(store: Arc<BatchStore>) -> Self {
-        Self(store)
-    }
-}
-
-#[async_trait::async_trait]
-impl AttestationStatusClient for LocalAttestationStatus {
-    async fn next_batch_to_attest(
-        &self,
-        ctx: &ctx::Ctx,
-    ) -> ctx::Result<Option<attester::BatchNumber>> {
-        self.0.next_batch_to_attest(ctx).await
-    }
-}
-
 /// Coordinate the attestation by showing the status as seen by the main node.
+#[derive(Debug, Clone)]
 pub struct AttestationStatus {
     /// Next batch number where voting is expected.
     ///
@@ -50,12 +31,19 @@ pub struct AttestationStatus {
     pub next_batch_to_attest: Option<attester::BatchNumber>,
 }
 
-/// The subscription over the attestation status which votes can monitor for change.
+/// The subscription over the attestation status which voters can monitor for change.
 pub type AttestationStatusReceiver = sync::watch::Receiver<AttestationStatus>;
 
 /// A [Watch] over an [AttestationStatus] which we can use to notify components about
 /// changes in the batch number the main node expects attesters to vote on.
-pub(crate) struct AttestationStatusWatch(Watch<AttestationStatus>);
+pub struct AttestationStatusWatch(Watch<AttestationStatus>);
+
+impl fmt::Debug for AttestationStatusWatch {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("AttestationStatusWatch")
+            .finish_non_exhaustive()
+    }
+}
 
 impl Default for AttestationStatusWatch {
     fn default() -> Self {
@@ -66,13 +54,23 @@ impl Default for AttestationStatusWatch {
 }
 
 impl AttestationStatusWatch {
+    /// Create a new [AttestationStatusWatch] paired up with an [AttestationStatusRunner] to keep it up to date.
+    pub fn new(
+        client: Box<dyn AttestationStatusClient>,
+        poll_interval: time::Duration,
+    ) -> (Arc<Self>, AttestationStatusRunner) {
+        let status = Arc::new(AttestationStatusWatch::default());
+        let runner = AttestationStatusRunner::new(status.clone(), client, poll_interval);
+        (status, runner)
+    }
+
     /// Subscribes to AttestationStatus updates.
-    pub(crate) fn subscribe(&self) -> AttestationStatusReceiver {
+    pub fn subscribe(&self) -> AttestationStatusReceiver {
         self.0.subscribe()
     }
 
     /// Set the next batch number to attest on and notify subscribers it changed.
-    pub(crate) async fn update(&self, next_batch_to_attest: attester::BatchNumber) {
+    pub async fn update(&self, next_batch_to_attest: attester::BatchNumber) {
         let this = self.0.lock().await;
         this.send_if_modified(|status| {
             if status.next_batch_to_attest == Some(next_batch_to_attest) {
@@ -81,5 +79,67 @@ impl AttestationStatusWatch {
             status.next_batch_to_attest = Some(next_batch_to_attest);
             true
         });
+    }
+}
+
+/// Use an [AttestationStatusClient] to periodically poll the main node and update the [AttestationStatusWatch].
+pub struct AttestationStatusRunner {
+    status: Arc<AttestationStatusWatch>,
+    client: Box<dyn AttestationStatusClient>,
+    poll_interval: time::Duration,
+}
+
+impl AttestationStatusRunner {
+    /// Create a new runner to poll the main node.
+    fn new(
+        status: Arc<AttestationStatusWatch>,
+        client: Box<dyn AttestationStatusClient>,
+        poll_interval: time::Duration,
+    ) -> Self {
+        Self {
+            status,
+            client,
+            poll_interval,
+        }
+    }
+
+    /// Run the poll loop.
+    pub async fn run(self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
+        loop {
+            match self.client.next_batch_to_attest(ctx).await {
+                Ok(Some(batch_number)) => {
+                    self.status.update(batch_number).await;
+                }
+                Ok(None) => tracing::debug!("waiting for attestation status..."),
+                Err(error) => tracing::error!(
+                    ?error,
+                    "failed to poll attestation status, retrying later..."
+                ),
+            }
+            if let Err(ctx::Canceled) = ctx.sleep(self.poll_interval).await {
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Implement the attestation status for the main node by returning the next to vote on from the [BatchStore].
+#[derive(Debug, Clone)]
+pub struct LocalAttestationStatusClient(Arc<BatchStore>);
+
+impl LocalAttestationStatusClient {
+    /// Create local attestation client form a [BatchStore].
+    pub fn new(store: Arc<BatchStore>) -> Self {
+        Self(store)
+    }
+}
+
+#[async_trait::async_trait]
+impl AttestationStatusClient for LocalAttestationStatusClient {
+    async fn next_batch_to_attest(
+        &self,
+        ctx: &ctx::Ctx,
+    ) -> ctx::Result<Option<attester::BatchNumber>> {
+        self.0.next_batch_to_attest(ctx).await
     }
 }

--- a/node/actors/network/src/gossip/attestation_status.rs
+++ b/node/actors/network/src/gossip/attestation_status.rs
@@ -1,25 +1,9 @@
 use std::fmt;
-use std::sync::Arc;
 
-use zksync_concurrency::{ctx, sync, time};
+use zksync_concurrency::sync;
 use zksync_consensus_roles::attester;
-use zksync_consensus_storage::BatchStore;
 
 use crate::watch::Watch;
-
-/// An interface which is used by attesters and nodes collecting votes over gossip to determine
-/// which is the next batch they are all supposed to be voting on, according to the main node.
-#[async_trait::async_trait]
-pub trait AttestationStatusClient: 'static + fmt::Debug + Send + Sync {
-    /// Get the next batch number for which the main node expects a batch QC to be formed.
-    ///
-    /// The API might return an error while genesis is being created, which we represent with `None`
-    /// here and mean that we'll have to try again later.
-    async fn next_batch_to_attest(
-        &self,
-        ctx: &ctx::Ctx,
-    ) -> ctx::Result<Option<attester::BatchNumber>>;
-}
 
 /// Coordinate the attestation by showing the status as seen by the main node.
 #[derive(Debug, Clone)]
@@ -54,16 +38,6 @@ impl Default for AttestationStatusWatch {
 }
 
 impl AttestationStatusWatch {
-    /// Create a new [AttestationStatusWatch] paired up with an [AttestationStatusRunner] to keep it up to date.
-    pub fn new(
-        client: Box<dyn AttestationStatusClient>,
-        poll_interval: time::Duration,
-    ) -> (Arc<Self>, AttestationStatusRunner) {
-        let status = Arc::new(AttestationStatusWatch::default());
-        let runner = AttestationStatusRunner::new(status.clone(), client, poll_interval);
-        (status, runner)
-    }
-
     /// Subscribes to AttestationStatus updates.
     pub fn subscribe(&self) -> AttestationStatusReceiver {
         self.0.subscribe()
@@ -79,67 +53,5 @@ impl AttestationStatusWatch {
             status.next_batch_to_attest = Some(next_batch_to_attest);
             true
         });
-    }
-}
-
-/// Use an [AttestationStatusClient] to periodically poll the main node and update the [AttestationStatusWatch].
-pub struct AttestationStatusRunner {
-    status: Arc<AttestationStatusWatch>,
-    client: Box<dyn AttestationStatusClient>,
-    poll_interval: time::Duration,
-}
-
-impl AttestationStatusRunner {
-    /// Create a new runner to poll the main node.
-    fn new(
-        status: Arc<AttestationStatusWatch>,
-        client: Box<dyn AttestationStatusClient>,
-        poll_interval: time::Duration,
-    ) -> Self {
-        Self {
-            status,
-            client,
-            poll_interval,
-        }
-    }
-
-    /// Run the poll loop.
-    pub async fn run(self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
-        loop {
-            match self.client.next_batch_to_attest(ctx).await {
-                Ok(Some(batch_number)) => {
-                    self.status.update(batch_number).await;
-                }
-                Ok(None) => tracing::debug!("waiting for attestation status..."),
-                Err(error) => tracing::error!(
-                    ?error,
-                    "failed to poll attestation status, retrying later..."
-                ),
-            }
-            if let Err(ctx::Canceled) = ctx.sleep(self.poll_interval).await {
-                return Ok(());
-            }
-        }
-    }
-}
-
-/// Implement the attestation status for the main node by returning the next to vote on from the [BatchStore].
-#[derive(Debug, Clone)]
-pub struct LocalAttestationStatusClient(Arc<BatchStore>);
-
-impl LocalAttestationStatusClient {
-    /// Create local attestation client form a [BatchStore].
-    pub fn new(store: Arc<BatchStore>) -> Self {
-        Self(store)
-    }
-}
-
-#[async_trait::async_trait]
-impl AttestationStatusClient for LocalAttestationStatusClient {
-    async fn next_batch_to_attest(
-        &self,
-        ctx: &ctx::Ctx,
-    ) -> ctx::Result<Option<attester::BatchNumber>> {
-        self.0.next_batch_to_attest(ctx).await
     }
 }

--- a/node/actors/network/src/gossip/batch_votes.rs
+++ b/node/actors/network/src/gossip/batch_votes.rs
@@ -53,8 +53,9 @@ pub(crate) struct BatchVotes {
     /// The minimum batch number for which we are still interested in votes.
     ///
     /// Because we only store 1 vote per attester the memory is very much bounded,
-    /// but this extra pruning mechanism can ge used to get rid of votes of attesters
-    /// who rotated out of the committee (which currently requires a re-genesis, but still).
+    /// but this extra pruning mechanism can be used to clear votes of attesters
+    /// who have been removed from the committee, as well as to get rid of the
+    /// last quorum we found and stored, and look for the a new one in the next round.
     pub(crate) min_batch_number: attester::BatchNumber,
 }
 

--- a/node/actors/network/src/gossip/batch_votes.rs
+++ b/node/actors/network/src/gossip/batch_votes.rs
@@ -38,7 +38,7 @@ impl BatchUpdateStats {
 pub(crate) struct BatchVotes {
     /// The latest vote received from each attester. We only keep the last one
     /// for now, hoping that with 1 minute batches there's plenty of time for
-    /// the quorum to be reached, but eventually we'll have to allow multiple
+    /// the quorum to be reached, but eventually we might have to allow multiple
     /// votes across different heights.
     pub(crate) votes: im::HashMap<attester::PublicKey, Arc<attester::Signed<attester::Batch>>>,
 
@@ -51,6 +51,10 @@ pub(crate) struct BatchVotes {
         im::OrdMap<attester::BatchNumber, im::HashMap<attester::BatchHash, attester::Weight>>,
 
     /// The minimum batch number for which we are still interested in votes.
+    ///
+    /// Because we only store 1 vote per attester the memory is very much bounded,
+    /// but this extra pruning mechanism can ge used to get rid of votes of attesters
+    /// who rotated out of the committee (which currently requires a re-genesis, but still).
     pub(crate) min_batch_number: attester::BatchNumber,
 }
 
@@ -131,20 +135,19 @@ impl BatchVotes {
 
     /// Check if we have achieved quorum for any of the batch hashes.
     ///
-    /// The return value is a vector because eventually we will be potentially waiting for
-    /// quorums on multiple heights simultaneously.
+    /// Returns the first quorum it finds, after which we expect that the state of the main node or L1
+    /// will indicate that attestation on the next height can happen, which will either naturally move
+    /// the QC, or we can do so by increasing the `min_batch_number`.
     ///
-    /// For repeated queries we can supply a skip list of heights for which we already saved the QC.
-    pub(super) fn find_quorums(
+    /// While we only store 1 vote per attester we'll only ever have at most one quorum anyway.
+    pub(super) fn find_quorum(
         &self,
         attesters: &attester::Committee,
         genesis: &attester::GenesisHash,
-        skip: impl Fn(attester::BatchNumber) -> bool,
-    ) -> Vec<attester::BatchQC> {
+    ) -> Option<attester::BatchQC> {
         let threshold = attesters.threshold();
         self.support
             .iter()
-            .filter(|(number, _)| !skip(**number))
             .flat_map(|(number, candidates)| {
                 candidates
                     .iter()
@@ -170,7 +173,7 @@ impl BatchVotes {
                         }
                     })
             })
-            .collect()
+            .next()
     }
 
     /// Set the minimum batch number for which we admit votes.

--- a/node/actors/network/src/gossip/mod.rs
+++ b/node/actors/network/src/gossip/mod.rs
@@ -12,10 +12,7 @@
 //! Static connections constitute a rigid "backbone" of the gossip network, which is insensitive to
 //! eclipse attack. Dynamic connections are supposed to improve the properties of the gossip
 //! network graph (minimize its diameter, increase connectedness).
-pub use self::attestation_status::{
-    AttestationStatusClient, AttestationStatusReceiver, AttestationStatusRunner,
-    AttestationStatusWatch, LocalAttestationStatusClient,
-};
+pub use self::attestation_status::{AttestationStatusReceiver, AttestationStatusWatch};
 pub use self::batch_votes::BatchVotesPublisher;
 use self::batch_votes::BatchVotesWatch;
 use crate::{gossip::ValidatorAddrsWatch, io, pool::PoolWatch, Config, MeteredStreamStats};

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -643,8 +643,8 @@ fn test_batch_votes_quorum() {
     let rng = &mut ctx::test_root(&ctx::RealClock).rng();
 
     for _ in 0..10 {
-        let size = rng.gen_range(1..20);
-        let keys: Vec<attester::SecretKey> = (0..size).map(|_| rng.gen()).collect();
+        let committee_size = rng.gen_range(1..20);
+        let keys: Vec<attester::SecretKey> = (0..committee_size).map(|_| rng.gen()).collect();
         let attesters = attester::Committee::new(keys.iter().map(|k| attester::WeightedAttester {
             key: k.public(),
             weight: rng.gen_range(1..=100),
@@ -681,12 +681,8 @@ fn test_batch_votes_quorum() {
             }
         }
 
-        if batches
-            .iter()
-            .find(|b| b.1 >= attesters.threshold())
-            .is_none()
-        {
-            // Check that if there was no quoroum then we don't find any.
+        // Check that if there was no quoroum then we don't find any.
+        if !batches.iter().any(|b| b.1 >= attesters.threshold()) {
             assert!(votes.find_quorum(&attesters, &genesis).is_none());
         }
 

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -673,27 +673,21 @@ fn test_batch_votes_quorum() {
 
             // Check that as soon as we have quorum it's found.
             if batches[b].1 >= attesters.threshold() {
-                let qs = votes.find_quorums(&attesters, &genesis, |_| false);
-                assert!(!qs.is_empty(), "should find quorum");
-                assert!(qs[0].message == *batch);
-                assert!(qs[0].signatures.keys().count() > 0);
+                let qc = votes
+                    .find_quorum(&attesters, &genesis)
+                    .expect("should find quorum");
+                assert!(qc.message == *batch);
+                assert!(qc.signatures.keys().count() > 0);
             }
         }
 
-        if let Some(quorum) = batches
+        if batches
             .iter()
             .find(|b| b.1 >= attesters.threshold())
-            .map(|(b, _)| b)
+            .is_none()
         {
-            // Check that a quorum can be skipped
-            assert!(votes
-                .find_quorums(&attesters, &genesis, |b| b == quorum.number)
-                .is_empty());
-        } else {
             // Check that if there was no quoroum then we don't find any.
-            assert!(votes
-                .find_quorums(&attesters, &genesis, |_| false)
-                .is_empty());
+            assert!(votes.find_quorum(&attesters, &genesis).is_none());
         }
 
         // Check that the minimum batch number prunes data.

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -1,6 +1,6 @@
 //! Network actor maintaining a pool of outbound and inbound connections to other nodes.
 use anyhow::Context as _;
-use gossip::{AttestationStatusReceiver, AttestationStatusWatch, BatchVotesPublisher};
+use gossip::{AttestationStatusWatch, BatchVotesPublisher};
 use std::sync::Arc;
 use tracing::Instrument as _;
 use zksync_concurrency::{
@@ -80,11 +80,6 @@ impl Network {
     /// Create a batch vote publisher to push attestations to gossip.
     pub fn batch_vote_publisher(&self) -> BatchVotesPublisher {
         BatchVotesPublisher(self.gossip.batch_votes.clone())
-    }
-
-    /// Subscribe to attestation status change notifications.
-    pub fn attestation_status_receiver(&self) -> AttestationStatusReceiver {
-        self.gossip.attestation_status.subscribe()
     }
 
     /// Handles a dispatcher message.

--- a/node/actors/network/src/testonly.rs
+++ b/node/actors/network/src/testonly.rs
@@ -1,7 +1,7 @@
 //! Testonly utilities.
 #![allow(dead_code)]
 use crate::{
-    gossip::{AttestationStatusRunner, AttestationStatusWatch, LocalAttestationStatusClient},
+    gossip::AttestationStatusWatch,
     io::{ConsensusInputMessage, Target},
     Config, GossipConfig, Network, RpcConfig, Runner,
 };
@@ -161,7 +161,8 @@ pub fn new_fullnode(rng: &mut impl Rng, peer: &Config) -> Config {
 /// Runner for Instance.
 pub struct InstanceRunner {
     net_runner: Runner,
-    attestation_status_runner: AttestationStatusRunner,
+    attestation_status: Arc<AttestationStatusWatch>,
+    batch_store: Arc<BatchStore>,
     terminate: channel::Receiver<()>,
 }
 
@@ -170,7 +171,16 @@ impl InstanceRunner {
     pub async fn run(mut self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
         scope::run!(ctx, |ctx, s| async {
             s.spawn_bg(self.net_runner.run(ctx));
-            s.spawn_bg(self.attestation_status_runner.run(ctx));
+            s.spawn_bg(async {
+                loop {
+                    if let Ok(Some(n)) = self.batch_store.next_batch_to_attest(ctx).await {
+                        self.attestation_status.update(n).await;
+                    }
+                    if ctx.sleep(time::Duration::seconds(1)).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            });
             let _ = self.terminate.recv(ctx).await;
             Ok(())
         })
@@ -188,17 +198,16 @@ impl Instance {
         batch_store: Arc<BatchStore>,
     ) -> (Self, InstanceRunner) {
         // Semantically we'd want this to be created at the same level as the stores,
-        // but doing so would introduce a lot of extra cruft in setting
-        // up tests that don't make any use of attestations.
-        let (attestation_status, attestation_status_runner) =
-            new_local_attestation_status(batch_store.clone());
+        // but doing so would introduce a lot of extra cruft in setting up tests.
+        let attestation_status = Arc::new(AttestationStatusWatch::default());
+
         let (actor_pipe, dispatcher_pipe) = pipe::new();
         let (net, net_runner) = Network::new(
             cfg,
             block_store,
-            batch_store,
+            batch_store.clone(),
             actor_pipe,
-            attestation_status,
+            attestation_status.clone(),
         );
         let (terminate_send, terminate_recv) = channel::bounded(1);
         (
@@ -209,7 +218,8 @@ impl Instance {
             },
             InstanceRunner {
                 net_runner,
-                attestation_status_runner,
+                attestation_status,
+                batch_store,
                 terminate: terminate_recv,
             },
         )
@@ -348,14 +358,4 @@ pub async fn instant_network(
     }
     tracing::info!("consensus network established");
     Ok(())
-}
-
-/// Create an attestation status and its runner based on a [BatchStore].
-pub fn new_local_attestation_status(
-    store: Arc<BatchStore>,
-) -> (Arc<AttestationStatusWatch>, AttestationStatusRunner) {
-    AttestationStatusWatch::new(
-        Box::new(LocalAttestationStatusClient::new(store)),
-        time::Duration::seconds(5),
-    )
 }

--- a/node/libs/storage/src/batch_store/metrics.rs
+++ b/node/libs/storage/src/batch_store/metrics.rs
@@ -7,9 +7,9 @@ pub(super) struct PersistentBatchStore {
     /// Latency of a successful `get_batch()` call.
     #[metrics(unit = vise::Unit::Seconds, buckets = vise::Buckets::LATENCIES)]
     pub(super) batch_latency: vise::Histogram<time::Duration>,
-    /// Latency of a successful `earliest_batch_number_to_sign()` call.
+    /// Latency of a successful `next_batch_to_attest_latency()` call.
     #[metrics(unit = vise::Unit::Seconds, buckets = vise::Buckets::LATENCIES)]
-    pub(super) earliest_batch_latency: vise::Histogram<time::Duration>,
+    pub(super) next_batch_to_attest_latency: vise::Histogram<time::Duration>,
     /// Latency of a successful `get_batch_to_sign()` call.
     #[metrics(unit = vise::Unit::Seconds, buckets = vise::Buckets::LATENCIES)]
     pub(super) batch_to_sign_latency: vise::Histogram<time::Duration>,

--- a/node/libs/storage/src/testonly/in_memory.rs
+++ b/node/libs/storage/src/testonly/in_memory.rs
@@ -139,7 +139,7 @@ impl PersistentBatchStore for BatchStore {
         Ok(certs.get(last_batch_number).cloned())
     }
 
-    async fn earliest_batch_number_to_sign(
+    async fn next_batch_to_attest(
         &self,
         _ctx: &ctx::Ctx,
     ) -> ctx::Result<Option<attester::BatchNumber>> {

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -9,11 +9,14 @@ use std::{
     path::PathBuf,
 };
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use zksync_concurrency::{ctx, net};
+use zksync_concurrency::{ctx, net, scope, time};
 use zksync_consensus_bft as bft;
 use zksync_consensus_crypto::{read_optional_text, read_required_text, Text, TextFmt};
 use zksync_consensus_executor as executor;
-use zksync_consensus_network::{gossip::LocalAttestationStatus, http};
+use zksync_consensus_network::{
+    gossip::{AttestationStatusRunner, AttestationStatusWatch, LocalAttestationStatusClient},
+    http,
+};
 use zksync_consensus_roles::{attester, node, validator};
 use zksync_consensus_storage::testonly::{TestMemoryStorage, TestMemoryStorageRunner};
 use zksync_consensus_utils::debug_page;
@@ -259,13 +262,20 @@ impl Configs {
     pub async fn make_executor(
         &self,
         ctx: &ctx::Ctx,
-    ) -> ctx::Result<(executor::Executor, TestMemoryStorageRunner)> {
+    ) -> ctx::Result<(executor::Executor, TestExecutorRunner)> {
         let replica_store = store::RocksDB::open(self.app.genesis.clone(), &self.database).await?;
         let store = TestMemoryStorage::new(ctx, &self.app.genesis).await;
 
-        // We don't have an implementation of an API in these servers, we can only use the stores.
-        let attestation_status_client =
-            Box::new(LocalAttestationStatus::new(store.batches.clone()));
+        // We don't have an API to poll in this setup, we can only create a local store based attestation client.
+        let (attestation_status, attestation_status_runner) = AttestationStatusWatch::new(
+            Box::new(LocalAttestationStatusClient::new(store.batches.clone())),
+            time::Duration::seconds(1),
+        );
+
+        let runner = TestExecutorRunner {
+            storage_runner: store.runner,
+            attestation_status_runner,
+        };
 
         let e = executor::Executor {
             config: executor::Config {
@@ -307,9 +317,9 @@ impl Configs {
                 .attester_key
                 .as_ref()
                 .map(|key| executor::Attester { key: key.clone() }),
-            attestation_status_client,
+            attestation_status,
         };
-        Ok((e, store.runner))
+        Ok((e, runner))
     }
 }
 
@@ -333,4 +343,21 @@ fn load_private_key(path: &PathBuf) -> anyhow::Result<PrivateKeyDer<'static>> {
 
     // Load and return a single private key.
     Ok(rustls_pemfile::private_key(&mut reader).map(|key| key.expect("Private key not found"))?)
+}
+
+pub struct TestExecutorRunner {
+    storage_runner: TestMemoryStorageRunner,
+    attestation_status_runner: AttestationStatusRunner,
+}
+
+impl TestExecutorRunner {
+    /// Runs the storage and the attestation status.
+    pub async fn run(self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
+        scope::run!(ctx, |ctx, s| async {
+            s.spawn(self.storage_runner.run(ctx));
+            s.spawn(self.attestation_status_runner.run(ctx));
+            Ok(())
+        })
+        .await
+    }
 }

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -298,6 +298,7 @@ impl Configs {
                             .expect("Could not obtain private key for debug page"),
                     }
                 }),
+                batch_poll_interval: time::Duration::seconds(1),
             },
             block_store: store.blocks,
             batch_store: store.batches,


### PR DESCRIPTION
## What ❔

Poll the main node for which batch height to vote on.

- [x] Return an `Option` rather than a `Vec` of `BatchQC` from `BatchVotes::find_quorum`: we decided not to implement voting on multiple heights for now, which makes it just confusing that a vector is returned.
- [x] Create an `AttestationStatusClient` trait with a method to poll the next `BatchNumber` to vote on, which can be injected as a `dyn` dependency
- [x] Create an `AttestationStatusWatch` that contains the next `BatchNumber` to vote on; this is updated by a single background task and listened to by multiple subscribers
- [x] Create an `AttestationStatusRunner` which is supposed to be started along with the `BatchStore` in `zksync-era` and polls the client; the point of this is to push out the poll interval configuration to the edge and make the `AttestationStatusWatch` the integration point
- [x] Change `AttesterRunner` to wait for the `AttestationStatusWatch` to change, then the payload to appear, then cast the vote; it doesn't need to worry about reverts because the node will restart if that happens
- [x] Change `run_batch_qc_finder` to wait for the `AttestationStatusWatch` to change, then wait for the next available QC, and save it; this might produce gaps which is normal on the external nodes, but undersireable on the main node - on the main node it only produces gaps if the attesters vote on higher heights despite the main node telling them not to, which if they are majority honest should not happen, and if they are not then what can we do anyway
- [x] Rename `PersistentBatchStore::earliest_batch_number_to_sign` to `next_batch_to_attest` in accordance with the new method on `consensus_dal`. 
- [ ] ~~Initialise `BatchNumber::min_batch_number` to by asking the main node where to resume from~~ This initialisation isn't necessary because 1) we decided that we'll only allow 1 vote per attester, so there is no attack vector of casting votes from batch 0 and 2) `run_batch_qc_finder` first waits for the API status to appear and then prunes all preceding data, so an older QC will not be saved. It was also undesirable to have to initialise from an API that might return nothing (or errors) for an unknown amount of time.

### Poll interval

The `AttesterStatusRunner` polls the API at fixed intervals without any exponential backoff. I thought 5s would be a reasonable default value. With 60s batches this seems fine because the *next* batch to sign will be signalled as soon as the current batch QC is inserted into the database, which is well ahead of time of when  the next batch and its commitment will be available. If we think we'll need to catch up with historical batch signatures it might be a bit slow. We generally still have to account for gossiping around the votes though, which in a large enough network could be on the order of several seconds as well.

### Potential deadlock

There is a pathological sequence of events that could prevent the feature from starting on a fresh database with no prior batch QCs:
1. Say we start from batch 0, and a QC is gathered, but saving it to the database (which is an async process) takes a long time on the main node.
2. Say it takes so long that batch 1 and batch 2 are created, but none of them have a QC yet.
3. Say we have two attesters A and B, and A polled the API when it showed batch 2, and the main node set its minimum batch number in the vote registry to batch 2 as well. 
4. Now the QC for batch 0 is saved to the database and the API indicates the next one to vote on is batch 1. 
5. Attester B casts its vote on batch 1 but it goes ignored by the main node vote registry because its looking for a quorum with at least batch number 2. 
6. Having missed an attestation the main node will never save a QC and never move on until it's restarted. 

Note that even if the registry minimum batch number was adjusted _down_ that might happen _after_ the vote for batch 1 has already been discarded, and because new votes are only pushed once through gossip there is no guarantee that it will get it again. 

The solution is coming in the form of fixing the starting point of gossip to be where the genesis starts, even if that means filling a potentially long history of batches in the beginning. See https://github.com/matter-labs/zksync-era/pull/2539

## Why ❔

We want to collect batch QCs without gaps, and for now put the main node in charge of what to vote on. The API to serve this information is in https://github.com/matter-labs/zksync-era/pull/2480 and this PR is the follow up to make polling that information part of the signing process.
