### PR TITLE
refactor: update/add committee data types (BFT-443)

### DIFF
--- a/node/libs/roles/src/attester/conv.rs
+++ b/node/libs/roles/src/attester/conv.rs
@@ -1,7 +1,4 @@
-use super::{
-    AggregateSignature, Batch, BatchHash, BatchNumber, BatchQC, Msg, MsgHash, MultiSig, PublicKey,
-    Signature, Signed, Signers, SyncBatch, WeightedAttester,
-};
+use super::{AggregateSignature, AttesterCommittee, Batch, BatchHash, BatchNumber, BatchQC, Msg, MsgHash, MultiSig, PublicKey, Signature, Signed, Signers, SyncBatch, WeightedAttester};
 use crate::{
     proto::attester::{self as proto, Attestation},
     validator::Payload,
@@ -141,6 +138,28 @@ impl ProtoFmt for WeightedAttester {
         }
     }
 }
+
+impl ProtoFmt for AttesterCommittee {
+    type Proto = proto::AttesterCommittee;
+
+    fn read(r: &Self::Proto) -> anyhow::Result<Self> {
+        Ok(Self {
+            members: r
+                .members
+                .iter()
+                .map(ProtoFmt::read)
+                .collect::<Result<_, _>>()
+                .context("members")?,
+        })
+    }
+
+    fn build(&self) -> Self::Proto {
+        Self::Proto {
+            members: self.members.iter().map(|x| x.build()).collect(),
+        }
+    }
+}
+
 
 impl ProtoFmt for Signers {
     type Proto = zksync_protobuf::proto::std::BitVector;

--- a/node/libs/roles/src/attester/messages/msg.rs
+++ b/node/libs/roles/src/attester/messages/msg.rs
@@ -276,3 +276,8 @@ pub struct WeightedAttester {
 
 /// Voting weight.
 pub type Weight = u64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttesterCommittee {
+    pub members: Vec<WeightedAttester>
+}

--- a/node/libs/roles/src/proto/attester.proto
+++ b/node/libs/roles/src/proto/attester.proto
@@ -62,6 +62,10 @@ message WeightedAttester {
   optional uint64 weight = 2; // required
 }
 
+message AttesterCommittee {
+   repeated WeightedAttester members = 1; // required
+}
+
 message Attestation {
   optional PublicKey key = 1; // required
   optional Signature sig = 2; // required

--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -198,4 +198,9 @@ message AggregateSignature {
 message WeightedValidator {
   optional PublicKey key = 1; // required
   optional uint64 weight = 2; // required
+  optional Signature pop = 3; // required
+}
+
+message ValidatorCommittee {
+   repeated WeightedValidator members = 1; // required
 }

--- a/node/libs/roles/src/proto/validator.proto
+++ b/node/libs/roles/src/proto/validator.proto
@@ -198,7 +198,7 @@ message AggregateSignature {
 message WeightedValidator {
   optional PublicKey key = 1; // required
   optional uint64 weight = 2; // required
-  optional Signature pop = 3; // required
+  optional Signature proof_of_possession = 3; // optional
 }
 
 message ValidatorCommittee {

--- a/node/libs/roles/src/validator/conv.rs
+++ b/node/libs/roles/src/validator/conv.rs
@@ -520,7 +520,7 @@ impl ProtoFmt for WeightedValidator {
         Ok(Self {
             key: read_required(&r.key).context("key")?,
             weight: *required(&r.weight).context("weight")?,
-            pop: read_required(&r.pop).context("pop")?,
+            proof_of_possession: read_optional(&r.proof_of_possession).context("proof_of_possession")?,
         })
     }
 
@@ -528,7 +528,7 @@ impl ProtoFmt for WeightedValidator {
         Self::Proto {
             key: Some(self.key.build()),
             weight: Some(self.weight),
-            pop: Some(self.pop.build()),
+            proof_of_possession: self.proof_of_possession.as_ref().map(ProtoFmt::build),
         }
     }
 }

--- a/node/libs/roles/src/validator/conv.rs
+++ b/node/libs/roles/src/validator/conv.rs
@@ -1,9 +1,4 @@
-use super::{
-    AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg,
-    FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg,
-    MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProtocolVersion, PublicKey,
-    ReplicaCommit, ReplicaPrepare, Signature, Signed, Signers, View, ViewNumber, WeightedValidator,
-};
+use super::{AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg, FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg, MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProtocolVersion, PublicKey, ReplicaCommit, ReplicaPrepare, Signature, Signed, Signers, ValidatorCommittee, View, ViewNumber, WeightedValidator};
 use crate::{
     attester::{self, WeightedAttester},
     node::SessionId,
@@ -525,6 +520,7 @@ impl ProtoFmt for WeightedValidator {
         Ok(Self {
             key: read_required(&r.key).context("key")?,
             weight: *required(&r.weight).context("weight")?,
+            pop: read_required(&r.pop).context("pop")?,
         })
     }
 
@@ -532,6 +528,29 @@ impl ProtoFmt for WeightedValidator {
         Self::Proto {
             key: Some(self.key.build()),
             weight: Some(self.weight),
+            pop: Some(self.pop.build()),
         }
     }
 }
+
+impl ProtoFmt for ValidatorCommittee {
+    type Proto = proto::ValidatorCommittee;
+
+    fn read(r: &Self::Proto) -> anyhow::Result<Self> {
+        Ok(Self {
+            members: r
+                .members
+                .iter()
+                .map(ProtoFmt::read)
+                .collect::<Result<_, _>>()
+                .context("members")?,
+        })
+    }
+
+    fn build(&self) -> Self::Proto {
+        Self::Proto {
+            members: self.members.iter().map(|x| x.build()).collect(),
+        }
+    }
+}
+

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -529,7 +529,7 @@ pub struct WeightedValidator {
     /// Validator weight inside the Committee.
     pub weight: Weight,
     /// Proof-of-possession (PoP) of the validator's public key (a signature over the public key)
-    pub pop: validator::Signature,
+    pub proof_of_possession: Option<validator::Signature>,
 }
 
 /// Voting weight;

--- a/node/libs/roles/src/validator/messages/consensus.rs
+++ b/node/libs/roles/src/validator/messages/consensus.rs
@@ -528,7 +528,15 @@ pub struct WeightedValidator {
     pub key: validator::PublicKey,
     /// Validator weight inside the Committee.
     pub weight: Weight,
+    /// Proof-of-possession (PoP) of the validator's public key (a signature over the public key)
+    pub pop: validator::Signature,
 }
 
 /// Voting weight;
 pub type Weight = u64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatorCommittee {
+    pub members: Vec<WeightedValidator>
+}
+

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -17,6 +17,7 @@ use rand::{
 };
 use std::sync::Arc;
 use zksync_concurrency::time;
+use zksync_consensus_crypto::ByteFmt;
 use zksync_consensus_utils::enum_util::Variant;
 
 /// Test setup specification.
@@ -173,6 +174,7 @@ impl From<SetupSpec> for Setup {
                     WeightedValidator {
                         key: k.public(),
                         weight: *w,
+                        pop: Signature::decode(&vec![]).unwrap(), // TODO(moshababo): implement
                     }
                 }))
                 .unwrap(),
@@ -437,6 +439,7 @@ impl Distribution<Committee> for Standard {
         let public_keys = (0..count).map(|_| WeightedValidator {
             key: rng.gen(),
             weight: 1,
+            pop: Signature::decode(&vec![]).unwrap(), // TODO(moshababo): implement
         });
         Committee::new(public_keys).unwrap()
     }

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -174,7 +174,7 @@ impl From<SetupSpec> for Setup {
                     WeightedValidator {
                         key: k.public(),
                         weight: *w,
-                        pop: Signature::decode(&vec![]).unwrap(), // TODO(moshababo): implement
+                        proof_of_possession: None,
                     }
                 }))
                 .unwrap(),
@@ -439,7 +439,7 @@ impl Distribution<Committee> for Standard {
         let public_keys = (0..count).map(|_| WeightedValidator {
             key: rng.gen(),
             weight: 1,
-            pop: Signature::decode(&vec![]).unwrap(), // TODO(moshababo): implement
+            proof_of_possession: None,
         });
         Committee::new(public_keys).unwrap()
     }


### PR DESCRIPTION
## What ❔

Adding minimally needed changes to support https://github.com/matter-labs/zksync-era/pull/2518, as part of committees rotation (BFT-484).

* Adding `pop: validator::Signature` (proof-of-possession) field to `WeightedValidator`.
* Adding `ValidatorCommittee` & `AttesterCommittee` types to provide protobuf formatting for DB store.

## Why ❔

These types cannot be placed in `zksync_node_consensus` because they are required by `zksync_dal::consensus_dal`, which is a dependency of `zksync_node_consensus`.



