### PR TITLE
removed panicking when peer_addr fails

### DIFF
--- a/node/actors/network/src/consensus/handshake/tests.rs
+++ b/node/actors/network/src/consensus/handshake/tests.rs
@@ -208,7 +208,7 @@ async fn test_invalid_signature() {
             frame::send_proto(ctx, &mut s1, &h).await
         });
         match inbound(ctx, &key0, genesis, &mut s0).await {
-            Err(Error::Signature(..)) => anyhow::Ok(()),
+            Err(Error::Signature(..)) => Ok(()),
             res => panic!("unexpected res: {res:?}"),
         }
     })

--- a/node/actors/network/src/consensus/tests.rs
+++ b/node/actors/network/src/consensus/tests.rs
@@ -4,7 +4,7 @@ use crate::{io, metrics, preface, rpc, testonly};
 use assert_matches::assert_matches;
 use rand::Rng;
 use std::collections::HashSet;
-use zksync_concurrency::{ctx, net, scope, testonly::abort_on_panic};
+use zksync_concurrency::{ctx, error::Wrap as _, net, scope, testonly::abort_on_panic};
 use zksync_consensus_roles::validator;
 use zksync_consensus_storage::testonly::TestMemoryStorage;
 use zksync_consensus_utils::enum_util::Variant as _;
@@ -181,11 +181,11 @@ async fn test_genesis_mismatch() {
 
         tracing::info!("Accept a connection with mismatching genesis.");
         let stream = metrics::MeteredStream::accept(ctx, &mut listener)
-            .await?
-            .context("accept()")?;
+            .await
+            .wrap("accept()")?;
         let (mut stream, endpoint) = preface::accept(ctx, stream)
             .await
-            .context("preface::accept()")?;
+            .wrap("preface::accept()")?;
         assert_eq!(endpoint, preface::Endpoint::ConsensusNet);
         tracing::info!("Expect the handshake to fail");
         let res = handshake::inbound(ctx, &setup.validator_keys[1], rng.gen(), &mut stream).await;

--- a/node/actors/network/src/gossip/handshake/tests.rs
+++ b/node/actors/network/src/gossip/handshake/tests.rs
@@ -223,7 +223,7 @@ async fn test_invalid_signature() {
             frame::send_proto(ctx, &mut s1, &h).await
         });
         match inbound(ctx, &cfg0, genesis, &mut s0).await {
-            Err(Error::Signature(..)) => anyhow::Ok(()),
+            Err(Error::Signature(..)) => Ok(()),
             res => panic!("unexpected res: {res:?}"),
         }
     })

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -17,7 +17,9 @@ use std::{
 };
 use tracing::Instrument as _;
 use zksync_concurrency::{
-    ctx, net, scope, sync,
+    ctx,
+    error::Wrap as _,
+    net, scope, sync,
     testonly::{abort_on_panic, set_timeout},
     time,
 };
@@ -351,11 +353,11 @@ async fn test_genesis_mismatch() {
 
         tracing::info!("Accept a connection with mismatching genesis.");
         let stream = metrics::MeteredStream::accept(ctx, &mut listener)
-            .await?
-            .context("accept()")?;
+            .await
+            .wrap("accept()")?;
         let (mut stream, endpoint) = preface::accept(ctx, stream)
             .await
-            .context("preface::accept()")?;
+            .wrap("preface::accept()")?;
         assert_eq!(endpoint, preface::Endpoint::GossipNet);
         tracing::info!("Expect the handshake to fail");
         let res = handshake::inbound(ctx, &cfgs[1].gossip, rng.gen(), &mut stream).await;


### PR DESCRIPTION
peer_addr() may fail if the network socket is closed. It needs to be handled gracefully.
I've also refactored some of the error handling to propagate cancellation better.