### PR TITLE
improve: AttestationStatusWatch::next_batch_to_attest non-optional (BFT-496)

### DIFF
--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -58,12 +58,9 @@ impl AttesterRunner {
         self.status.mark_changed();
 
         loop {
-            let Some(batch_number) = sync::changed(ctx, &mut self.status)
+            let batch_number = sync::changed(ctx, &mut self.status)
                 .await?
-                .next_batch_to_attest
-            else {
-                continue;
-            };
+                .next_batch_to_attest;
 
             tracing::info!(%batch_number, "attestation status");
 

--- a/node/actors/executor/src/tests.rs
+++ b/node/actors/executor/src/tests.rs
@@ -30,7 +30,7 @@ fn config(cfg: &network::Config) -> Config {
 /// The test executors below are not running with attesters, so we just create an [AttestationStatusWatch]
 /// that will never be updated.
 fn never_attest() -> Arc<AttestationStatusWatch> {
-    Arc::new(AttestationStatusWatch::default())
+    Arc::new(AttestationStatusWatch::new(attester::BatchNumber(0)))
 }
 
 fn validator(

--- a/node/actors/network/src/gossip/mod.rs
+++ b/node/actors/network/src/gossip/mod.rs
@@ -171,12 +171,9 @@ impl Network {
 
         loop {
             // Wait until the status indicates that we're ready to sign the next batch.
-            let Some(next_batch_number) = sync::changed(ctx, &mut recv_status)
+            let next_batch_number = sync::changed(ctx, &mut recv_status)
                 .await?
-                .next_batch_to_attest
-            else {
-                continue;
-            };
+                .next_batch_to_attest;
 
             // Get rid of all previous votes. We don't expect this to go backwards without regenesis, which will involve a restart.
             self.batch_votes

--- a/node/actors/network/src/gossip/tests/fetch_blocks.rs
+++ b/node/actors/network/src/gossip/tests/fetch_blocks.rs
@@ -26,6 +26,7 @@ async fn test_simple() {
     scope::run!(ctx, |ctx, s| async {
         let store = TestMemoryStorage::new(ctx, &setup.genesis).await;
         s.spawn_bg(store.runner.run(ctx));
+
         let (_node, runner) = crate::testonly::Instance::new(
             cfg.clone(),
             store.blocks.clone(),

--- a/node/actors/network/src/testonly.rs
+++ b/node/actors/network/src/testonly.rs
@@ -17,7 +17,7 @@ use zksync_concurrency::{
     ctx::{self, channel},
     io, limiter, net, scope, sync, time,
 };
-use zksync_consensus_roles::{node, validator};
+use zksync_consensus_roles::{attester, node, validator};
 use zksync_consensus_storage::{BatchStore, BlockStore};
 use zksync_consensus_utils::pipe;
 
@@ -199,7 +199,8 @@ impl Instance {
     ) -> (Self, InstanceRunner) {
         // Semantically we'd want this to be created at the same level as the stores,
         // but doing so would introduce a lot of extra cruft in setting up tests.
-        let attestation_status = Arc::new(AttestationStatusWatch::default());
+        let attestation_status =
+            Arc::new(AttestationStatusWatch::new(attester::BatchNumber::default()));
 
         let (actor_pipe, dispatcher_pipe) = pipe::new();
         let (net, net_runner) = Network::new(

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -264,8 +264,14 @@ impl Configs {
         let replica_store = store::RocksDB::open(self.app.genesis.clone(), &self.database).await?;
         let store = TestMemoryStorage::new(ctx, &self.app.genesis).await;
 
+        let next_batch = store
+            .batches
+            .next_batch_to_attest(ctx)
+            .await?
+            .unwrap_or_default();
+
         // We don't have an API to poll in this setup, we can only create a local store based attestation client.
-        let attestation_status = Arc::new(AttestationStatusWatch::default());
+        let attestation_status = Arc::new(AttestationStatusWatch::new(next_batch));
         let attestation_status_runner = AttestationStatusRunner::new_from_store(
             attestation_status.clone(),
             store.batches.clone(),


### PR DESCRIPTION
## What ❔

`AttestationStatusWatch` must be initialised with a `BatchNumber`, it cannot have `None` any more. `AttestationStatusRunner::new` was replaced with the `AttestationStatusRunner::init` method which asynchronously polls the API until the first value is returned, and then returns itself along with the `AttestationStatusWatch` it created. This can then be passed to the `Executor`, while the `AttestationStatusRunner::run` will keep the status up to date in the background.

## Why ❔

In the review of https://github.com/matter-labs/era-consensus/pull/161 it was observed that the `Executor` can wait until this data is available. In theory it is only unavailable if the main node API is down, in which case an external node couldn't pull Genesis either and would probably fail during startup, or if the Genesis itself is still under construction in the database, which is a transient state under which an external node as mentioned would not start, and apparently the main node doesn't need the `Executor` to get over it. By removing `None` as an option for `next_batch_to_attest` the state is easier to reason about.
