### PR TITLE
fix: AttestationStatusRunner::poll_until_some return after success (BFT-496)

### DIFF
--- a/node/actors/executor/src/attestation.rs
+++ b/node/actors/executor/src/attestation.rs
@@ -188,9 +188,10 @@ impl AttestationStatusRunner {
             match self.client.next_batch_to_attest(ctx).await {
                 Ok(Some(next_batch_to_attest)) => {
                     self.status.update(next_batch_to_attest).await;
+                    return Ok(());
                 }
                 Ok(None) => {
-                    tracing::debug!("waiting for attestation status...")
+                    tracing::info!("waiting for attestation status...")
                 }
                 Err(error) => {
                     tracing::error!(


### PR DESCRIPTION
## What ❔

Fixes `AttestationStatusRunner::poll_until_some` to return after a successful poll. Originally it returned a value, then decided to write it into the field and forgot to add a return statement.

## Why ❔

Tests in https://github.com/matter-labs/zksync-era/pull/2544 time out because the initialisation never completes and the `Executor` is never started.
