### PR TITLE
fix: Set cargo-deny to version 0.15.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
   push:
     # Caches of different branches are isolated, so first presubmit on a given pull request is slow.
     # However workflows of pull request have read-only access to the cache of the target branch.
@@ -19,7 +19,6 @@ env:
 
 jobs:
   check-build-test:
-
     runs-on: [ubuntu-22.04-github-hosted-16core]
 
     defaults:
@@ -38,6 +37,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-deny
+          version: "0.15.1"
       - name: deny
         run: cargo deny check
       - name: fmt


### PR DESCRIPTION
## What ❔

Sets the version of `cargo-deny` installed on CI to 0.15.1

I looked at https://github.com/EmbarkStudios/cargo-deny/blame/0.15.1/deny.template.toml vs the latest but can't see anything that explains why something like [licensed.unlicensed](https://github.com/matter-labs/era-consensus/blob/d8068480000abbf4ce025c1de4ee53d14fd648bf/node/deny.toml#L25) doesn't work any more when the PR suggested in the error only says its default changed from `warn` to `deny`. Need to investigate further for what the new syntax should be.

## Why ❔

The latest 0.16 causes deprecations in fields which stop the build: https://github.com/matter-labs/era-consensus/actions/runs/10215658697/job/28265688492?pr=169