### PR TITLE
chore: Remove deprecated cargo deny fields

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-deny
-          version: "0.15.1"
       - name: deny
         run: cargo deny check
       - name: fmt

--- a/node/deny.toml
+++ b/node/deny.toml
@@ -1,31 +1,15 @@
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-musl" },
     { triple = "x86_64-apple-darwin" },
 ]
 
 [advisories]
-# The lint level for unmaintained crates
-unmaintained = "deny"
 # The lint level for crates that have been yanked from their source registry
 yanked = "deny"
-# The lint level for crates with security notices.
-notice = "deny"
-# Threshold for security vulnerabilities, any vulnerability with a CVSS score
-# lower than the range specified will be ignored. Note that ignored advisories
-# will still output a note when they are encountered.
-# * None - CVSS Score 0.0
-# * Low - CVSS Score 0.1 - 3.9
-# * Medium - CVSS Score 4.0 - 6.9
-# * High - CVSS Score 7.0 - 8.9
-# * Critical - CVSS Score 9.0 - 10.0
-severity-threshold = "medium"
+
 
 [licenses]
-# We want to deny every license that isn't explicitly added to the allow list.
-unlicensed = "deny"
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 # We  want to set a high confidence threshold for license detection.
 confidence-threshold = 1.0
 # Licenses that are allowed to be used in crates.
@@ -73,9 +57,9 @@ skip = [
     { name = "base64", version = "0.21.7" },
 
     # Old versions required by vise-exporter.
-    { name = "http", version = "0.2.12"},
-    { name = "http-body", version = "0.4.6"},
-    { name = "hyper", version = "0.14.28"},
+    { name = "http", version = "0.2.12" },
+    { name = "http-body", version = "0.4.6" },
+    { name = "hyper", version = "0.14.28" },
 ]
 
 [sources]


### PR DESCRIPTION
## What ❔

Follow up for https://github.com/matter-labs/era-consensus/pull/171

Removes fields which are deprecated according to https://github.com/matter-labs/era-consensus/actions/runs/10215658697/job/28265688492?pr=169 

See the link in the error messages to `cargo-deny` PR 611 which describes the new behaviour, and then the link to PR 606 which explains why the fields were removed. 

I don't think the deprecated fields need to be moved, the explanation says they made no sense; except for `[graph].target`.

## Why ❔

So that we can keep using the latest version of `cargo-deny` without failing the build.