### PR TITLE
Bump version to 0.1.0-rc.6

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "tester"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_bft"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "blst",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_executor"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_network"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_storage"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_tools"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "anyhow",
  "heck",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,23 +22,23 @@ homepage = "https://matter-labs.io/"
 repository = "https://github.com/matter-labs/era-consensus"
 license = "MIT OR Apache-2.0"
 keywords = ["blockchain", "zksync"]
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 
 [workspace.dependencies]
 # Crates from this repo.
-zksync_consensus_bft = { version = "=0.1.0-rc.5", path = "actors/bft" }
-zksync_consensus_crypto = { version = "=0.1.0-rc.5", path = "libs/crypto" }
-zksync_consensus_executor = { version = "=0.1.0-rc.5", path = "actors/executor" }
-zksync_consensus_network = { version = "=0.1.0-rc.5", path = "actors/network" }
-zksync_consensus_roles = { version = "=0.1.0-rc.5", path = "libs/roles" }
-zksync_consensus_storage = { version = "=0.1.0-rc.5", path = "libs/storage" }
-zksync_consensus_tools = { version = "=0.1.0-rc.5", path = "tools" }
-zksync_consensus_utils = { version = "=0.1.0-rc.5", path = "libs/utils" }
+zksync_consensus_bft = { version = "=0.1.0-rc.6", path = "actors/bft" }
+zksync_consensus_crypto = { version = "=0.1.0-rc.6", path = "libs/crypto" }
+zksync_consensus_executor = { version = "=0.1.0-rc.6", path = "actors/executor" }
+zksync_consensus_network = { version = "=0.1.0-rc.6", path = "actors/network" }
+zksync_consensus_roles = { version = "=0.1.0-rc.6", path = "libs/roles" }
+zksync_consensus_storage = { version = "=0.1.0-rc.6", path = "libs/storage" }
+zksync_consensus_tools = { version = "=0.1.0-rc.6", path = "tools" }
+zksync_consensus_utils = { version = "=0.1.0-rc.6", path = "libs/utils" }
 
 # Crates from this repo that might become independent in the future.
-zksync_concurrency = { version = "=0.1.0-rc.5", path = "libs/concurrency" }
-zksync_protobuf = { version = "=0.1.0-rc.5", path = "libs/protobuf" }
-zksync_protobuf_build = { version = "=0.1.0-rc.5", path = "libs/protobuf_build" }
+zksync_concurrency = { version = "=0.1.0-rc.6", path = "libs/concurrency" }
+zksync_protobuf = { version = "=0.1.0-rc.6", path = "libs/protobuf" }
+zksync_protobuf_build = { version = "=0.1.0-rc.6", path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
 pairing = { package = "pairing_ce", version = "=0.28.6" }


### PR DESCRIPTION
## What ❔

Bumps the version to `0.1.0-rc.6`

## Why ❔

So that we can release https://github.com/matter-labs/era-consensus/pull/170 and https://github.com/matter-labs/era-consensus/pull/169 to make zksync-era backwards compatible.
