### PR TITLE
made attestation metrics scrapeable

### DIFF
--- a/node/actors/network/src/gossip/attestation/metrics.rs
+++ b/node/actors/network/src/gossip/attestation/metrics.rs
@@ -1,3 +1,7 @@
+//! Attestation metrics.
+use super::Controller;
+use std::sync::Weak;
+
 /// Metrics related to the gossiping of L1 batch votes.
 #[derive(Debug, vise::Metrics)]
 #[metrics(prefix = "network_gossip_attestation")]
@@ -15,5 +19,26 @@ pub(crate) struct Metrics {
     pub(crate) weight_collected: vise::Gauge<f64>,
 }
 
-#[vise::register]
-pub(super) static METRICS: vise::Global<Metrics> = vise::Global::new();
+impl Metrics {
+    /// Registers metrics to a global collector.
+    pub(crate) fn register(ctrl: Weak<Controller>) {
+        #[vise::register]
+        static COLLECTOR: vise::Collector<Option<Metrics>> = vise::Collector::new();
+        let res = COLLECTOR.before_scrape(move || {
+            ctrl.upgrade().and_then(|ctrl| {
+                let ctrl = (*ctrl.state.subscribe().borrow()).clone()?;
+                let m = Metrics::default();
+                m.batch_number.set(ctrl.info.batch_to_attest.number.0);
+                m.committee_size.set(ctrl.info.committee.len());
+                m.votes_collected.set(ctrl.votes.len());
+                #[allow(clippy::float_arithmetic)]
+                m.weight_collected
+                    .set(ctrl.total_weight as f64 / ctrl.info.committee.total_weight() as f64);
+                Some(m)
+            })
+        });
+        if let Err(err) = res {
+            tracing::warn!("Failed registering attestation metrics: {err:#}");
+        }
+    }
+}

--- a/node/actors/network/src/lib.rs
+++ b/node/actors/network/src/lib.rs
@@ -74,6 +74,7 @@ impl Network {
     /// Registers metrics for this state.
     pub fn register_metrics(self: &Arc<Self>) {
         metrics::NetworkGauges::register(Arc::downgrade(self));
+        self.gossip.attestation.register_metrics();
     }
 
     /// Handles a dispatcher message.


### PR DESCRIPTION
It is easier to manage gauge metrics if they are scraped on demand, rather than actively updated.