### PR TITLE
feat: support for broadcasting unknown data

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -1033,25 +1033,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b538e4231443a5b9c507caee3356f016d832cf7393d2d90f03ea3180d4e3fbc"
 dependencies = [
  "byteorder",
- "ff_derive_ce",
  "hex",
  "rand 0.4.6",
  "serde",
-]
-
-[[package]]
-name = "ff_derive_ce"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96fbccd88dbb1fac4ee4a07c2fcc4ca719a74ffbd9d2b9d41d8c8eb073d8b20"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2188,19 +2172,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "pairing_ce"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843b5b6fb63f00460f611dbc87a50bbbb745f0dfe5cbf67ca89299c79098640e"
-dependencies = [
- "byteorder",
- "cfg-if",
- "ff_ce",
- "rand 0.4.6",
- "serde",
-]
 
 [[package]]
 name = "parking"
@@ -4061,7 +4032,6 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-traits",
- "pairing_ce",
  "rand 0.4.6",
  "rand 0.8.5",
  "sha3",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,6 @@ zksync_protobuf = { version = "=0.1.0-rc.12", path = "libs/protobuf" }
 zksync_protobuf_build = { version = "=0.1.0-rc.12", path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
-pairing = { package = "pairing_ce", version = "=0.28.6" }
 vise = "0.2.0"
 vise-exporter = "0.2.0"
 

--- a/node/actors/network/src/consensus/tests.rs
+++ b/node/actors/network/src/consensus/tests.rs
@@ -168,13 +168,16 @@ async fn test_genesis_mismatch() {
             .validator_addrs
             .update(
                 &setup.genesis.validators,
-                &[Arc::new(setup.validator_keys[1].sign_msg(
-                    validator::NetAddress {
-                        addr: *cfgs[1].server_addr,
-                        version: 0,
-                        timestamp: ctx.now_utc(),
-                    },
-                ))],
+                &[Arc::new(
+                    setup.validator_keys[1].sign_msg(
+                        validator::NetAddress {
+                            addr: *cfgs[1].server_addr,
+                            version: 0,
+                            timestamp: ctx.now_utc(),
+                        }
+                        .into(),
+                    ),
+                )],
             )
             .await
             .unwrap();

--- a/node/actors/network/src/gossip/tests/mod.rs
+++ b/node/actors/network/src/gossip/tests/mod.rs
@@ -90,25 +90,30 @@ fn mk_version<R: Rng>(rng: &mut R) -> u64 {
 }
 
 #[derive(Default)]
-struct View(im::HashMap<validator::PublicKey, Arc<validator::Signed<validator::NetAddress>>>);
+struct View(
+    im::HashMap<validator::PublicKey, Arc<validator::Signed<validator::EncodedNetAddress>>>,
+);
 
 fn mk_netaddr(
     key: &validator::SecretKey,
     addr: std::net::SocketAddr,
     version: u64,
     timestamp: time::Utc,
-) -> validator::Signed<validator::NetAddress> {
-    key.sign_msg(validator::NetAddress {
-        addr,
-        version,
-        timestamp,
-    })
+) -> validator::Signed<validator::EncodedNetAddress> {
+    key.sign_msg(
+        validator::NetAddress {
+            addr,
+            version,
+            timestamp,
+        }
+        .into(),
+    )
 }
 
 fn random_netaddr<R: Rng>(
     rng: &mut R,
     key: &validator::SecretKey,
-) -> Arc<validator::Signed<validator::NetAddress>> {
+) -> Arc<validator::Signed<validator::EncodedNetAddress>> {
     Arc::new(mk_netaddr(
         key,
         mk_addr(rng),
@@ -123,7 +128,7 @@ fn update_netaddr<R: Rng>(
     key: &validator::SecretKey,
     version_diff: i64,
     timestamp_diff: time::Duration,
-) -> Arc<validator::Signed<validator::NetAddress>> {
+) -> Arc<validator::Signed<validator::EncodedNetAddress>> {
     Arc::new(mk_netaddr(
         key,
         mk_addr(rng),
@@ -133,15 +138,18 @@ fn update_netaddr<R: Rng>(
 }
 
 impl View {
-    fn insert(&mut self, entry: Arc<validator::Signed<validator::NetAddress>>) {
+    fn insert(&mut self, entry: Arc<validator::Signed<validator::EncodedNetAddress>>) {
         self.0.insert(entry.key.clone(), entry);
     }
 
-    fn get(&mut self, key: &validator::SecretKey) -> Arc<validator::Signed<validator::NetAddress>> {
+    fn get(
+        &mut self,
+        key: &validator::SecretKey,
+    ) -> Arc<validator::Signed<validator::EncodedNetAddress>> {
         self.0.get(&key.public()).unwrap().clone()
     }
 
-    fn as_vec(&self) -> Vec<Arc<validator::Signed<validator::NetAddress>>> {
+    fn as_vec(&self) -> Vec<Arc<validator::Signed<validator::EncodedNetAddress>>> {
         self.0.values().cloned().collect()
     }
 }

--- a/node/actors/network/src/rpc/push_validator_addrs.rs
+++ b/node/actors/network/src/rpc/push_validator_addrs.rs
@@ -20,7 +20,7 @@ impl super::Rpc for Rpc {
 
 /// Contains a batch of new ValidatorAddrs that the sender has learned about.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Req(pub(crate) Vec<Arc<validator::Signed<validator::NetAddress>>>);
+pub(crate) struct Req(pub(crate) Vec<Arc<validator::Signed<validator::EncodedNetAddress>>>);
 
 impl ProtoFmt for Req {
     type Proto = proto::PushValidatorAddrs;

--- a/node/actors/network/src/rpc/testonly.rs
+++ b/node/actors/network/src/rpc/testonly.rs
@@ -30,7 +30,7 @@ impl Distribution<rpc::push_validator_addrs::Req> for Standard {
             (0..n)
                 .map(|_| {
                     let key: validator::SecretKey = rng.gen();
-                    let addr: validator::NetAddress = rng.gen();
+                    let addr: validator::EncodedNetAddress = rng.gen();
                     Arc::new(key.sign_msg(addr))
                 })
                 .collect(),

--- a/node/libs/crypto/Cargo.toml
+++ b/node/libs/crypto/Cargo.toml
@@ -19,7 +19,6 @@ hex.workspace = true
 k256.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
-pairing.workspace = true
 rand.workspace = true
 rand04.workspace = true
 sha3.workspace = true

--- a/node/libs/roles/src/proto/validator/messages.proto
+++ b/node/libs/roles/src/proto/validator/messages.proto
@@ -130,7 +130,7 @@ message Msg {
   oneof t {// required
     ConsensusMsg consensus = 1;
     bytes session_id = 2;
-    NetAddress net_address = 3;
+    bytes net_address = 3; // encoded NetAddress.
   }
 }
 

--- a/node/libs/roles/src/validator/messages/discovery.rs
+++ b/node/libs/roles/src/validator/messages/discovery.rs
@@ -16,6 +16,39 @@ pub struct NetAddress {
     pub timestamp: time::Utc,
 }
 
+/// Protobuf encoded NetAddress.
+/// It is used to avoid reencoding data and
+/// therefore losing the unknown fields.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EncodedNetAddress(NetAddress, Vec<u8>);
+
+impl std::ops::Deref for EncodedNetAddress {
+    type Target = NetAddress;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<NetAddress> for EncodedNetAddress {
+    fn from(x: NetAddress) -> Self {
+        let bytes = zksync_protobuf::canonical(&x);
+        Self(x, bytes)
+    }
+}
+
+impl EncodedNetAddress {
+    /// Constructs EncodedNetAddress from
+    /// encoded representation.
+    pub fn new(bytes: Vec<u8>) -> anyhow::Result<Self> {
+        let x = zksync_protobuf::decode(&bytes)?;
+        Ok(Self(x, bytes))
+    }
+    /// Reference to encoded represetation.
+    pub fn encoded(&self) -> &[u8] {
+        &self.1
+    }
+}
+
 impl NetAddress {
     /// Checks if `self` is a newer version than `b`.
     pub fn is_newer(&self, b: &Self) -> bool {

--- a/node/libs/roles/src/validator/messages/discovery.rs
+++ b/node/libs/roles/src/validator/messages/discovery.rs
@@ -43,7 +43,7 @@ impl EncodedNetAddress {
         let x = zksync_protobuf::decode(&bytes)?;
         Ok(Self(x, bytes))
     }
-    /// Reference to encoded represetation.
+    /// Reference to encoded representation.
     pub fn encoded(&self) -> &[u8] {
         &self.1
     }

--- a/node/libs/roles/src/validator/messages/msg.rs
+++ b/node/libs/roles/src/validator/messages/msg.rs
@@ -1,5 +1,5 @@
 //! Generic message types.
-use super::{ConsensusMsg, NetAddress};
+use super::{ConsensusMsg, EncodedNetAddress};
 use crate::{node::SessionId, validator};
 use std::fmt;
 use zksync_consensus_crypto::{keccak256, ByteFmt, Text, TextFmt};
@@ -13,7 +13,7 @@ pub enum Msg {
     /// authentication
     SessionId(SessionId),
     /// validator discovery
-    NetAddress(NetAddress),
+    NetAddress(EncodedNetAddress),
 }
 
 impl Msg {
@@ -47,7 +47,7 @@ impl Variant<Msg> for SessionId {
     }
 }
 
-impl Variant<Msg> for NetAddress {
+impl Variant<Msg> for EncodedNetAddress {
     fn insert(self) -> Msg {
         Msg::NetAddress(self)
     }

--- a/node/libs/roles/src/validator/testonly.rs
+++ b/node/libs/roles/src/validator/testonly.rs
@@ -1,10 +1,10 @@
 //! Test-only utilities.
 use super::{
     AggregateSignature, BlockHeader, BlockNumber, ChainId, CommitQC, Committee, ConsensusMsg,
-    FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit, LeaderPrepare, Msg,
-    MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC, ProofOfPossession,
-    ProtocolVersion, PublicKey, ReplicaCommit, ReplicaPrepare, SecretKey, Signature, Signed,
-    Signers, View, ViewNumber, WeightedValidator,
+    EncodedNetAddress, FinalBlock, ForkNumber, Genesis, GenesisHash, GenesisRaw, LeaderCommit,
+    LeaderPrepare, Msg, MsgHash, NetAddress, Payload, PayloadHash, Phase, PrepareQC,
+    ProofOfPossession, ProtocolVersion, PublicKey, ReplicaCommit, ReplicaPrepare, SecretKey,
+    Signature, Signed, Signers, View, ViewNumber, WeightedValidator,
 };
 use crate::{attester, validator::LeaderSelectionMode};
 use bit_vec::BitVec;
@@ -469,6 +469,12 @@ impl Distribution<Phase> for Standard {
             1 => Phase::Commit,
             _ => unreachable!(),
         }
+    }
+}
+
+impl Distribution<EncodedNetAddress> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> EncodedNetAddress {
+        rng.gen::<NetAddress>().into()
     }
 }
 


### PR DESCRIPTION
Re-encoding the protobuf message has a side effect of dropping unknown fields, which changes the hash of the message.
With this change we will be able to add data to the message broadcasted by the validator, in a backward compatible way.