### PR TITLE
feat: loadtest improvements

### DIFF
--- a/infrastructure/loadtests/ansible/playbook.yml
+++ b/infrastructure/loadtests/ansible/playbook.yml
@@ -86,7 +86,7 @@
         mode: "0755"
 
     - name: Start executor binary in background
-      shell: "nohup ./executor > /var/log/zksync-bft.log 2>&1 &"
+      shell: "nohup ./executor --database=./database > /var/log/zksync-bft.log 2>&1 &"
       args:
         chdir: /etc/zksync-bft/
       environment:

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -133,7 +133,7 @@ impl StateMachine {
         // In particular it is not guaranteed that the leader has the finalized block when
         // sending the NewView, so it might need to wait for the finalized block.
         //
-        // Note that for this process to work e2e, the replicas should NOT ignore th NewView from
+        // Note that for this process to work e2e, the replicas should NOT ignore the NewView from
         // the leader, even if they already advanced to the given view.
         // Note that the order of NewView and proposal messages doesn't matter, because
         // proposal is a superset of NewView message.

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -55,17 +55,18 @@ impl StateMachine {
         let message = &signed_message.msg;
         let author = &signed_message.key;
 
+        // If the replica is already in this view, then ignore it.
+        // TODO: allow for the same view number for the proposer.
+        if message.view().number <= self.view_number {
+            return Err(Error::Old {
+                current_view: self.view_number,
+            });
+        }
+
         // Check that the message signer is in the validator committee.
         if !self.config.genesis().validators.contains(author) {
             return Err(Error::NonValidatorSigner {
                 signer: author.clone().into(),
-            });
-        }
-
-        // If the message is from a past view, ignore it.
-        if message.view().number < self.view_number {
-            return Err(Error::Old {
-                current_view: self.view_number,
             });
         }
 
@@ -118,9 +119,23 @@ impl StateMachine {
     ) -> ctx::Result<()> {
         // Update the state machine.
         self.view_number = view;
+        metrics::METRICS.replica_view_number.set(self.view_number.0);
         self.phase = validator::Phase::Prepare;
+        // It is important that the proposal and new_view messages from the leader
+        // will contain the same justification.
+        // Proposal cannot be produced before previous block is processed,
+        // therefore leader needs to make sure that the high_commit_qc is delivered
+        // to all replicas, so that the finalized block is distributed over the network.
+        // In particular it is not guaranteed that the leader has the finalized block when
+        // sending the NewView, so it might need to wait for the finalized block.
+        //
+        // Note that for this process to work e2e, the replicas should NOT ignore th NewView from
+        // the leader, even if they already advanced to the given view.
+        // Note that the order of NewView and proposal messages doesn't matter, because
+        // proposal is a superset of NewView message.
+        let justification = self.get_justification();
         self.proposer_sender
-            .send(Some(self.get_justification()))
+            .send(Some(justification.clone()))
             .expect("justification_watch.send() failed");
 
         // Clear the block proposal cache.
@@ -139,7 +154,7 @@ impl StateMachine {
                 .secret_key
                 .sign_msg(validator::ConsensusMsg::ReplicaNewView(
                     validator::ReplicaNewView {
-                        justification: self.get_justification(),
+                        justification: justification.clone(),
                     },
                 )),
         };
@@ -147,7 +162,6 @@ impl StateMachine {
 
         // Log the event and update the metrics.
         tracing::info!("Starting view {}", self.view_number);
-        metrics::METRICS.replica_view_number.set(self.view_number.0);
         let now = ctx.now();
         metrics::METRICS
             .view_latency

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -55,9 +55,13 @@ impl StateMachine {
         let message = &signed_message.msg;
         let author = &signed_message.key;
 
-        // If the replica is already in this view, then ignore it.
-        // TODO: allow for the same view number for the proposer.
-        if message.view().number <= self.view_number {
+        // If the replica is already in this view (and the message is NOT from the leader), then ignore it.
+        // See `start_new_view()` for explanation why we need to process the message from the
+        // leader.
+        if message.view().number < self.view_number
+            || (message.view().number == self.view_number
+                && author != &self.config.genesis().view_leader(self.view_number))
+        {
             return Err(Error::Old {
                 current_view: self.view_number,
             });

--- a/node/components/bft/src/chonky_bft/tests/new_view.rs
+++ b/node/components/bft/src/chonky_bft/tests/new_view.rs
@@ -141,11 +141,12 @@ async fn replica_new_view_old() {
     zksync_concurrency::testonly::abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     scope::run!(ctx, |ctx, s| async {
-        let (mut util, runner) = UTHarness::new(ctx, 1).await;
+        let (mut util, runner) = UTHarness::new(ctx, 2).await;
         s.spawn_bg(runner.run(ctx));
 
         let replica_new_view = util.new_replica_new_view(ctx).await;
-        let replica_new_view = util.owner_key().sign_msg(replica_new_view);
+        // Sign the messages with non-leader key.
+        let replica_new_view = util.keys[1].sign_msg(replica_new_view);
 
         // Process new_view twice. The second time it shouldn't be accepted.
         util.process_replica_new_view(ctx, replica_new_view.clone())

--- a/node/components/bft/src/testonly/node.rs
+++ b/node/components/bft/src/testonly/node.rs
@@ -1,8 +1,7 @@
 use crate::{testonly, FromNetworkMessage, PayloadManager, ToNetworkMessage};
 use anyhow::Context as _;
 use std::sync::Arc;
-use zksync_concurrency::time;
-use zksync_concurrency::{ctx, ctx::channel, scope, sync};
+use zksync_concurrency::{ctx, ctx::channel, scope, sync, time};
 use zksync_consensus_network as network;
 use zksync_consensus_storage as storage;
 use zksync_consensus_storage::testonly::in_memory;

--- a/node/components/network/src/config.rs
+++ b/node/components/network/src/config.rs
@@ -14,16 +14,10 @@ pub struct RpcConfig {
     pub push_validator_addrs_rate: limiter::Rate,
     /// Max rate of sending/receiving push_block_store_state messages.
     pub push_block_store_state_rate: limiter::Rate,
-    /// Max rate of sending/receiving push_batch_store_state messages.
-    pub push_batch_store_state_rate: limiter::Rate,
     /// Max rate of sending/receiving `get_block` RPCs.
     pub get_block_rate: limiter::Rate,
-    /// Max rate of sending/receiving `get_batch` RPCs.
-    pub get_batch_rate: limiter::Rate,
     /// Timeout for the `get_block` RPC.
     pub get_block_timeout: Option<time::Duration>,
-    /// Timeout for the `get_batch` RPC.
-    pub get_batch_timeout: Option<time::Duration>,
     /// Max rate of sending/receiving consensus messages.
     pub consensus_rate: limiter::Rate,
     /// Max rate of sending/receiving PushBatchVotes RPCs.
@@ -39,22 +33,13 @@ impl Default for RpcConfig {
             },
             push_block_store_state_rate: limiter::Rate {
                 burst: 2,
-                refresh: time::Duration::milliseconds(300),
-            },
-            push_batch_store_state_rate: limiter::Rate {
-                burst: 2,
-                refresh: time::Duration::milliseconds(300),
+                refresh: time::Duration::milliseconds(200),
             },
             get_block_rate: limiter::Rate {
                 burst: 10,
                 refresh: time::Duration::milliseconds(100),
             },
-            get_batch_rate: limiter::Rate {
-                burst: 10,
-                refresh: time::Duration::milliseconds(100),
-            },
             get_block_timeout: Some(time::Duration::seconds(10)),
-            get_batch_timeout: Some(time::Duration::seconds(10)),
             consensus_rate: limiter::Rate {
                 burst: 10,
                 refresh: time::Duration::ZERO,

--- a/node/components/network/src/consensus/mod.rs
+++ b/node/components/network/src/consensus/mod.rs
@@ -125,7 +125,7 @@ pub(crate) struct Network {
 impl rpc::Handler<rpc::consensus::Rpc> for &Network {
     /// Here we bound the buffering of incoming consensus messages.
     fn max_req_size(&self) -> usize {
-        self.gossip.cfg.max_block_size.saturating_add(kB)
+        self.gossip.cfg.max_block_size.saturating_add(100 * kB)
     }
 
     async fn handle(

--- a/node/libs/concurrency/src/ctx/clock.rs
+++ b/node/libs/concurrency/src/ctx/clock.rs
@@ -45,7 +45,9 @@ pub struct RealClock;
 impl RealClock {
     /// Current time according to the monotone clock.
     pub fn now(&self) -> time::Instant {
-        time::Instant::now()
+        // We use `now()` from tokio, so that `tokio::time::pause()`
+        // works in tests.
+        tokio::time::Instant::now().into_std().into()
     }
     /// Current time according to the system/walltime clock.
     pub fn now_utc(&self) -> time::Utc {

--- a/node/tools/src/bin/localnet_config.rs
+++ b/node/tools/src/bin/localnet_config.rs
@@ -75,7 +75,7 @@ fn main() -> anyhow::Result<()> {
                 .metrics_server_port
                 .map(|port| SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port)),
             genesis: setup.genesis.clone(),
-            max_payload_size: 100000,
+            max_payload_size: args.payload_size,
             node_key: node_keys[i].clone(),
             validator_key: validator_keys.get(i).cloned(),
             attester_key: attester_keys.get(i).cloned(),

--- a/node/tools/src/bin/localnet_config.rs
+++ b/node/tools/src/bin/localnet_config.rs
@@ -75,7 +75,7 @@ fn main() -> anyhow::Result<()> {
                 .metrics_server_port
                 .map(|port| SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port)),
             genesis: setup.genesis.clone(),
-            max_payload_size: 1000000,
+            max_payload_size: 100000,
             node_key: node_keys[i].clone(),
             validator_key: validator_keys.get(i).cloned(),
             attester_key: attester_keys.get(i).cloned(),

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -20,7 +20,7 @@ struct Cli {
     #[arg(long, conflicts_with = "config_path")]
     config: Option<String>,
     /// Path to the rocksdb database of the node.
-    /// If not provided, an inmemory database will be used instead.
+    /// If not provided, an in-memory database will be used instead.
     #[arg(long)]
     database: Option<PathBuf>,
 }

--- a/node/tools/src/main.rs
+++ b/node/tools/src/main.rs
@@ -20,8 +20,9 @@ struct Cli {
     #[arg(long, conflicts_with = "config_path")]
     config: Option<String>,
     /// Path to the rocksdb database of the node.
-    #[arg(long, default_value = "./database")]
-    database: PathBuf,
+    /// If not provided, an inmemory database will be used instead.
+    #[arg(long)]
+    database: Option<PathBuf>,
 }
 
 impl Cli {


### PR DESCRIPTION
Removed verification of redundant NewView messages.
Fixed incompatibility between zksync_conncurrency and `tokio::time::pause()`.
Added in-memory mode to the test node binary.
Fixed `payload_size` flag in the test node binary.
Removed obsolete rate limits from the network config.