### PR TITLE
fix: Replicas forget messages and halt on restart

### DIFF
--- a/node/components/bft/src/chonky_bft/block.rs
+++ b/node/components/bft/src/chonky_bft/block.rs
@@ -24,7 +24,7 @@ impl StateMachine {
         };
 
         tracing::info!(
-            "Finalized block {}: {:#?}",
+            "Finalized block number {} with payload hash {:#?}.",
             block.header().number,
             block.header().payload,
         );

--- a/node/components/bft/src/chonky_bft/commit.rs
+++ b/node/components/bft/src/chonky_bft/commit.rs
@@ -100,6 +100,11 @@ impl StateMachine {
         // ----------- All checks finished. Now we process the message. --------------
 
         // We add the message to the incrementally-constructed QC.
+        tracing::debug!(
+            "ChonkyBFT replica - Received a commit message from {:#?}. Message:\n{:#?}",
+            author,
+            message
+        );
         let commit_qc = self
             .commit_qcs_cache
             .entry(message.view.number)
@@ -141,6 +146,13 @@ impl StateMachine {
             .unwrap()
             .remove(message)
             .unwrap();
+
+        tracing::info!("ChonkyBFT replica - We have a commit QC with weight {} at view {} for block number {} with hash {:#?}.",
+            weight,
+            commit_qc.view().number.0,
+            commit_qc.message.proposal.number.0,
+            commit_qc.message.proposal.payload,
+        );
 
         // We update our state with the new commit QC.
         self.process_commit_qc(ctx, &commit_qc)

--- a/node/components/bft/src/chonky_bft/mod.rs
+++ b/node/components/bft/src/chonky_bft/mod.rs
@@ -112,6 +112,7 @@ impl StateMachine {
     /// This is the main entry point for the state machine,
     /// potentially triggering state modifications and message sending to the executor.
     pub(crate) async fn run(mut self, ctx: &ctx::Ctx) -> ctx::Result<()> {
+        tracing::info!("Starting ChonkyBFT replica.");
         self.view_start = ctx.now();
 
         // If this is the first view, we immediately timeout. This will force the replicas
@@ -119,6 +120,7 @@ impl StateMachine {
         // next view. This is necessary because the first view is not justified by any
         // previous view.
         if self.view_number == validator::ViewNumber(0) {
+            tracing::debug!("ChonkyBFT replica - Starting view 0, immediately timing out.");
             self.start_timeout(ctx).await?;
         }
 
@@ -154,15 +156,17 @@ impl StateMachine {
                             match err {
                                 // If the error is internal, we stop here.
                                 proposal::Error::Internal(err) => {
-                                    tracing::error!("on_proposal: internal error: {err:#}");
+                                    tracing::error!(
+                                        "ChonkyBFT replica - on_proposal: internal error - {err:#}"
+                                    );
                                     return Err(err);
                                 }
                                 // If the error is due to an old message, we log it at a lower level.
                                 proposal::Error::Old { .. } => {
-                                    tracing::debug!("on_proposal: {err:#}");
+                                    tracing::debug!("ChonkyBFT replica - on_proposal: {err:#}");
                                 }
                                 _ => {
-                                    tracing::warn!("on_proposal: {err:#}");
+                                    tracing::warn!("ChonkyBFT replica - on_proposal: {err:#}");
                                 }
                             }
                             Err(())
@@ -181,15 +185,17 @@ impl StateMachine {
                             match err {
                                 // If the error is internal, we stop here.
                                 commit::Error::Internal(err) => {
-                                    tracing::error!("on_commit: internal error: {err:#}");
+                                    tracing::error!(
+                                        "ChonkyBFT replica - on_commit: internal error: {err:#}"
+                                    );
                                     return Err(err);
                                 }
                                 // If the error is due to an old message, we log it at a lower level.
                                 commit::Error::Old { .. } => {
-                                    tracing::debug!("on_commit: {err:#}");
+                                    tracing::debug!("ChonkyBFT replica - on_commit: {err:#}");
                                 }
                                 _ => {
-                                    tracing::warn!("on_commit: {err:#}");
+                                    tracing::warn!("ChonkyBFT replica - on_commit: {err:#}");
                                 }
                             }
                             Err(())
@@ -208,15 +214,17 @@ impl StateMachine {
                             match err {
                                 // If the error is internal, we stop here.
                                 timeout::Error::Internal(err) => {
-                                    tracing::error!("on_timeout: internal error: {err:#}");
+                                    tracing::error!(
+                                        "ChonkyBFT replica - on_timeout: internal error: {err:#}"
+                                    );
                                     return Err(err);
                                 }
                                 // If the error is due to an old message, we log it at a lower level.
                                 timeout::Error::Old { .. } => {
-                                    tracing::debug!("on_timeout: {err:#}");
+                                    tracing::debug!("ChonkyBFT replica - on_timeout: {err:#}");
                                 }
                                 _ => {
-                                    tracing::warn!("on_timeout: {err:#}");
+                                    tracing::warn!("ChonkyBFT replica - on_timeout: {err:#}");
                                 }
                             }
                             Err(())
@@ -235,15 +243,17 @@ impl StateMachine {
                             match err {
                                 // If the error is internal, we stop here.
                                 new_view::Error::Internal(err) => {
-                                    tracing::error!("on_new_view: internal error: {err:#}");
+                                    tracing::error!(
+                                        "ChonkyBFT replica - on_new_view: internal error: {err:#}"
+                                    );
                                     return Err(err);
                                 }
                                 // If the error is due to an old message, we log it at a lower level.
                                 new_view::Error::Old { .. } => {
-                                    tracing::debug!("on_new_view: {err:#}");
+                                    tracing::debug!("ChonkyBFT replica - on_new_view: {err:#}");
                                 }
                                 _ => {
-                                    tracing::warn!("on_new_view: {err:#}");
+                                    tracing::warn!("ChonkyBFT replica - on_new_view: {err:#}");
                                 }
                             }
                             Err(())
@@ -274,6 +284,13 @@ impl StateMachine {
         {
             return Ok(());
         }
+
+        tracing::debug!(
+            "ChonkyBFT replica - Processing newer CommitQC: current view: {}, QC view: {}",
+            self.view_number.0,
+            qc.view().number.0,
+        );
+
         self.high_commit_qc = Some(qc.clone());
         self.save_block(ctx, qc).await.wrap("save_block()")
     }

--- a/node/components/bft/src/chonky_bft/mod.rs
+++ b/node/components/bft/src/chonky_bft/mod.rs
@@ -134,14 +134,9 @@ impl StateMachine {
                 return Ok(());
             }
 
-            // Check for timeout. If we are already in a timeout phase, we don't
-            // timeout again. Note though that the underlying network implementation
-            // needs to keep retrying messages until they are delivered. Otherwise
-            // the consensus can halt!
+            // Check for timeout.
             let Some(req) = recv.ok() else {
-                if self.phase != validator::Phase::Timeout {
-                    self.start_timeout(ctx).await?;
-                }
+                self.start_timeout(ctx).await?;
                 continue;
             };
 

--- a/node/components/bft/src/chonky_bft/mod.rs
+++ b/node/components/bft/src/chonky_bft/mod.rs
@@ -295,6 +295,7 @@ impl StateMachine {
         Ok(())
     }
 
+    /// Processes a (already verified) TimeoutQC. It bumps the local high_timeout_qc.
     pub(crate) async fn process_timeout_qc(
         &mut self,
         ctx: &ctx::Ctx,

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -125,6 +125,7 @@ impl StateMachine {
         self.view_number = view;
         metrics::METRICS.replica_view_number.set(self.view_number.0);
         self.phase = validator::Phase::Prepare;
+
         // It is important that the proposal and new_view messages from the leader
         // will contain the same justification.
         // Proposal cannot be produced before previous block is processed,
@@ -166,6 +167,7 @@ impl StateMachine {
 
         // Log the event and update the metrics.
         tracing::info!("Starting view {}", self.view_number);
+
         let now = ctx.now();
         metrics::METRICS
             .view_latency

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -97,20 +97,10 @@ impl StateMachine {
                 .process_commit_qc(ctx, qc)
                 .await
                 .wrap("process_commit_qc()")?,
-            validator::ProposalJustification::Timeout(qc) => {
-                if let Some(high_qc) = qc.high_qc() {
-                    self.process_commit_qc(ctx, high_qc)
-                        .await
-                        .wrap("process_commit_qc()")?;
-                }
-                if self
-                    .high_timeout_qc
-                    .as_ref()
-                    .map_or(true, |old| old.view.number < qc.view.number)
-                {
-                    self.high_timeout_qc = Some(qc.clone());
-                }
-            }
+            validator::ProposalJustification::Timeout(qc) => self
+                .process_timeout_qc(ctx, qc)
+                .await
+                .wrap("process_timeout_qc()")?,
         };
 
         // If the message is for a future view, we need to start a new view.

--- a/node/components/bft/src/chonky_bft/new_view.rs
+++ b/node/components/bft/src/chonky_bft/new_view.rs
@@ -85,6 +85,12 @@ impl StateMachine {
 
         // ----------- All checks finished. Now we process the message. --------------
 
+        tracing::debug!(
+            "ChonkyBFT replica - Received a new view message from {:#?}. Message:\n{:#?}",
+            author,
+            message,
+        );
+
         // Update the state machine.
         match &message.justification {
             validator::ProposalJustification::Commit(qc) => self
@@ -121,6 +127,8 @@ impl StateMachine {
         ctx: &ctx::Ctx,
         view: validator::ViewNumber,
     ) -> ctx::Result<()> {
+        tracing::info!("ChonkyBFT replica - Starting view number {}.", view);
+
         // Update the state machine.
         self.view_number = view;
         metrics::METRICS.replica_view_number.set(self.view_number.0);
@@ -163,11 +171,13 @@ impl StateMachine {
                     },
                 )),
         };
+        tracing::debug!(
+            "ChonkyBFT replica - Broadcasting new view message at start of view. Message:\n{:#?}",
+            output_message.message
+        );
         self.outbound_channel.send(output_message);
 
-        // Log the event and update the metrics.
-        tracing::info!("Starting view {}", self.view_number);
-
+        // Update the metrics.
         let now = ctx.now();
         metrics::METRICS
             .view_latency

--- a/node/components/bft/src/chonky_bft/proposal.rs
+++ b/node/components/bft/src/chonky_bft/proposal.rs
@@ -249,20 +249,10 @@ impl StateMachine {
                 .process_commit_qc(ctx, qc)
                 .await
                 .wrap("process_commit_qc()")?,
-            validator::ProposalJustification::Timeout(qc) => {
-                if let Some(high_qc) = qc.high_qc() {
-                    self.process_commit_qc(ctx, high_qc)
-                        .await
-                        .wrap("process_commit_qc()")?;
-                }
-                if self
-                    .high_timeout_qc
-                    .as_ref()
-                    .map_or(true, |old| old.view.number < qc.view.number)
-                {
-                    self.high_timeout_qc = Some(qc.clone());
-                }
-            }
+            validator::ProposalJustification::Timeout(qc) => self
+                .process_timeout_qc(ctx, qc)
+                .await
+                .wrap("process_timeout_qc()")?,
         };
 
         // Backup our state.

--- a/node/components/bft/src/chonky_bft/proposal.rs
+++ b/node/components/bft/src/chonky_bft/proposal.rs
@@ -172,6 +172,10 @@ impl StateMachine {
                 // we might just have started from a snapshot state. It just means that we have the state of the chain
                 // up to the previous block.
                 if let Some(prev) = implied_block_number.prev() {
+                    tracing::debug!(
+                        "ChonkyBFT replica - Waiting for previous block (number {}) to be stored before verifying proposal.",
+                        prev.0
+                    );
                     self.config
                         .block_store
                         .wait_until_persisted(&ctx.with_deadline(self.view_timeout), prev)
@@ -180,6 +184,10 @@ impl StateMachine {
                 }
 
                 // Execute the payload.
+                tracing::debug!(
+                    "ChonkyBFT replica - Verifying proposal for block number {}.",
+                    implied_block_number.0
+                );
                 if let Err(err) = self
                     .config
                     .payload_manager
@@ -193,6 +201,10 @@ impl StateMachine {
                 }
 
                 // The proposal is valid. We cache it, waiting for it to be committed.
+                tracing::debug!(
+                    "ChonkyBFT replica - Caching proposal for block number {}.",
+                    implied_block_number.0
+                );
                 self.block_proposal_cache
                     .entry(implied_block_number)
                     .or_default()
@@ -201,6 +213,14 @@ impl StateMachine {
                 payload.hash()
             }
         };
+
+        tracing::info!(
+            "ChonkyBFT replica - Received a proposal from {:#?} at view {} for block number {} with payload hash {:#?}.",
+            author,
+            view.0,
+            implied_block_number.0,
+            block_hash
+        );
 
         // ----------- All checks finished. Now we process the message. --------------
 
@@ -249,6 +269,10 @@ impl StateMachine {
         self.backup_state(ctx).await.wrap("backup_state()")?;
 
         // Broadcast our commit message.
+        tracing::debug!(
+            "ChonkyBFT replica - Broadcasting commit vote:\n{:#?}",
+            commit_vote
+        );
         let output_message = ConsensusInputMessage {
             message: self
                 .config

--- a/node/components/bft/src/chonky_bft/proposer.rs
+++ b/node/components/bft/src/chonky_bft/proposer.rs
@@ -25,6 +25,10 @@ pub(crate) async fn run_proposer(
         }
 
         // Create a proposal for the given justification, within the timeout.
+        tracing::info!(
+            "ChonkyBFT proposer - Creating a proposal for view {}.",
+            justification.view().number
+        );
         let proposal = match create_proposal(
             &ctx.with_timeout(cfg.view_timeout),
             cfg.clone(),
@@ -47,7 +51,10 @@ pub(crate) async fn run_proposer(
         let msg = cfg
             .secret_key
             .sign_msg(validator::ConsensusMsg::LeaderProposal(proposal));
-
+        tracing::debug!(
+            "ChonkyBFT proposer - Broadcasting proposal. Message:\n{:#?}",
+            msg.msg
+        );
         network_sender.send(ConsensusInputMessage { message: msg });
     }
 }

--- a/node/components/bft/src/chonky_bft/timeout.rs
+++ b/node/components/bft/src/chonky_bft/timeout.rs
@@ -147,18 +147,9 @@ impl StateMachine {
         );
 
         // We update our state with the new timeout QC.
-        if let Some(commit_qc) = timeout_qc.high_qc() {
-            self.process_commit_qc(ctx, commit_qc)
-                .await
-                .wrap("process_commit_qc()")?;
-        }
-        if self
-            .high_timeout_qc
-            .as_ref()
-            .map_or(true, |old| old.view.number < timeout_qc.view.number)
-        {
-            self.high_timeout_qc = Some(timeout_qc.clone());
-        }
+        self.process_timeout_qc(ctx, &timeout_qc)
+            .await
+            .wrap("process_timeout_qc()")?;
 
         // Start a new view.
         self.start_new_view(ctx, message.view.number.next()).await?;

--- a/node/components/bft/src/lib.rs
+++ b/node/components/bft/src/lib.rs
@@ -61,7 +61,7 @@ impl Config {
         genesis.verify().context("genesis().verify()")?;
 
         if let Some(prev) = genesis.first_block.prev() {
-            tracing::info!("Waiting for the pre-fork blocks to be persisted");
+            tracing::info!("Waiting for the pre-fork blocks to be persisted.");
             if let Err(ctx::Canceled) = self.block_store.wait_until_persisted(ctx, prev).await {
                 return Ok(());
             }
@@ -79,7 +79,10 @@ impl Config {
         .await?;
 
         let res = scope::run!(ctx, |ctx, s| async {
-            tracing::info!("Starting consensus component {:?}", cfg.secret_key.public());
+            tracing::info!(
+                "Starting consensus component. Validator public key: {:?}.",
+                cfg.secret_key.public()
+            );
 
             s.spawn(async { replica.run(ctx).await.wrap("replica.run()") });
             s.spawn_bg(async {

--- a/node/components/bft/src/testonly/run.rs
+++ b/node/components/bft/src/testonly/run.rs
@@ -294,7 +294,7 @@ async fn run_nodes_twins(
         // * identify the partition they are in based on their network id
         // * either broadcast to all other instances in the partition, or find out the network
         //   identity of the target validator and send to it iff they are in the same partition
-        // * simulate the gossiping of finalized blockss
+        // * simulate the gossiping of finalized blocks.
         scope::run!(ctx, |ctx, s| async move {
             for (i, (port, recv)) in recvs.into_iter().enumerate() {
                 let gossip_send = gossip_send.clone();

--- a/spec/informal-spec/README.md
+++ b/spec/informal-spec/README.md
@@ -6,7 +6,7 @@ We’ll assume there’s a static set of nodes. Each node has 3 components: repl
 
 There's a couple of considerations that are not described in the pseudo-code:
 
-- **Network model**. Messages might be delivered out of order, but we don’t guarantee eventual delivery for *all* messages. Actually, our network only guarantees eventual delivery of the most recent message for each type. That’s because each replica only stores the last outgoing message of each type in memory, and always tries to deliver those messages whenever it reconnects with another replica.
+- **Network model**. We use a stronger form of the partially synchronous model. Up until GST, messages can be delayed, delivered out of order or even _dropped_ altogether. After GST the network becomes synchronous.
 - **Garbage collection**. We can’t store all messages, the goal here is to bound the number of messages that each replica stores, in order to avoid DoS attacks. We handle messages like this:
     - `NewView` messages are never stored, so no garbage collection is necessary.
     - We keep all `Proposal` messages until the proposal (or a proposal with the same block number) is finalized (which means any honest replica having both the `Proposal` and the corresponding `CommitQC`, we assume that any honest replica in that situation will immediately broadcast the block on the p2p network.


### PR DESCRIPTION
## What ❔

- Fixes issue with replicas not sending timeouts/new views after restarting.
- Adds more logs for better visibility.

## Why ❔
From Slack: 

> I've deployed ChonkyBFT with multiple (3) validators on stage two weeks ago and it has halted a few times, always requiring a regenesis (basically a hard fork) to restart it.
> Here's the issue. Right now, when we send a message it is added to a queue in our network component. There the component retries sending the message until it succeeds. That's basically what we describe in network model [here](https://github.com/matter-labs/era-consensus/tree/main/spec/informal-spec). The problem though is that when a node is restarted it loses that queue of messages it is trying to send. The only data we persist is [this](https://github.com/matter-labs/era-consensus/blob/main/node/libs/storage/src/replica_store.rs#L34-L49). What seems to be happening is this:
> 
> 1. All replicas timeout.
> 2. Some replicas crash before they can send their timeout message.
> 3. When those replicas restart they remember having timed out and won't try sending the timeout message again. It can happen if the crash happens [here](https://github.com/matter-labs/era-consensus/blob/main/node/components/bft/src/chonky_bft/timeout.rs#L160-L182).
> 4. If >f replicas crash in this particular way, the consensus halts.
> 
> This is easier to happen in stage where we have f=0 and nodes are restarted several times a day. The solution to this is quite easy, we just keep resending timeouts in the bft component. It doesn't really alter our spec, it's just an implementation detail.
> But this got me thinking about the deeper issue here, which is that we can't guarantee eventual delivery of messages. No matter if we persist all the messages to a database, or try to be really careful about where we send messages, it is always possible that a node just forgets all messages that it is trying to send. If we assume that arbitrary messages can be dropped, then it's trivial to halt the consensus:
> 
> 1. All replicas timeout.
> 2. Subset of replicas A receives all timeouts and moves to next view.
> 3. Subset of replicas B receives no messages from the other subset. No timeouts or new views.
> 4. Now GST happens and no messages are being dropped.
> 5. Set A and B are in different views. They are all sending timeouts forever without any set reaching a quorum. Unfortunately set A does not resend new view messages since they already sent them when they changed view. If they did, set B would synchronize with set A.
> 
>  We should change our assumption from "After GST all messages are delivered including past ones" to "After GST all messages start being delivered". This would strengthen our security model to allow messages being dropped until GST. This is a more realistic model for the networks we operate in and kind of a stronger form of the partially synchronous model.
> The changes are minimal, we need to keep resending timeouts like I said before. In addition, whenever we timeout we also send a new view message. So, we basically run a loop sending new view and timeout messages until we progress. It is simple to see that this would work. For any set of replicas in different views and with no memory of past messages, they will keep sending new views until they all synchronize to the same view and then the timeouts will move everyone to the next view.
