### PR TITLE
ci: add manual workflow for crates.io publishing

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -1,0 +1,38 @@
+name: Publish crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-build:
+        type: boolean
+        description: 'Build the workspace before release.'
+        required: false
+        default: true
+      run-tests:
+        type: boolean
+        description: 'Run tests before release.'
+        required: false
+        default: false
+      org-owner:
+        type: string
+        description: 'Organization to add as owner of the crates.'
+        required: false
+        default: 'github:matter-labs:crates-io'
+
+
+jobs:
+
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: matterlabs-ci-runner-highdisk
+    steps:
+      - name: Publish crates
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
+        with:
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }} # Slack webhook for notifications
+          cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }} # Crates.io token for publishing
+          org_owner: ${{ inputs.org-owner }}
+          run_build: ${{ inputs.run-build }}
+          run_tests: ${{ inputs.run-tests }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          dependencies: 'clang libclang-dev'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,3 +30,4 @@ jobs:
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file
       update-cargo-lock: true                          # Update Cargo.lock file
       publish-to-crates-io: true                       # Enable publishing to crates.io
+      dependencies: 'clang libclang-dev'               # Additional Linux dependencies to install


### PR DESCRIPTION
## What ❔

* [x] Add manual workflow for crates.io publishing.
* [x] Add required rocksdb clang dependencies 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix crates.io publishing.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
