### PR TITLE
ci: fix workspace path in publish crates

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }} # Slack webhook for notifications
           cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }} # Crates.io token for publishing
+          workspace_path: 'node'
           org_owner: ${{ inputs.org-owner }}
           run_build: ${{ inputs.run-build }}
           run_tests: ${{ inputs.run-tests }}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,19 +26,19 @@ version    = "0.9.0" # x-release-please-version
 
 [workspace.dependencies]
 # Crates from this repo.
-zksync_consensus_bft      = { path = "components/bft" }
-zksync_consensus_crypto   = { path = "libs/crypto" }
-zksync_consensus_executor = { path = "components/executor" }
-zksync_consensus_network  = { path = "components/network" }
-zksync_consensus_roles    = { path = "libs/roles" }
-zksync_consensus_storage  = { path = "libs/storage" }
-zksync_consensus_tools    = { path = "tools" }
-zksync_consensus_utils    = { path = "libs/utils" }
+zksync_consensus_bft      = { version = "=0.9.0", path = "components/bft" }
+zksync_consensus_crypto   = { version = "=0.9.0", path = "libs/crypto" }
+zksync_consensus_executor = { version = "=0.9.0", path = "components/executor" }
+zksync_consensus_network  = { version = "=0.9.0", path = "components/network" }
+zksync_consensus_roles    = { version = "=0.9.0", path = "libs/roles" }
+zksync_consensus_storage  = { version = "=0.9.0", path = "libs/storage" }
+zksync_consensus_tools    = { version = "=0.9.0", path = "tools" }
+zksync_consensus_utils    = { version = "=0.9.0", path = "libs/utils" }
 
 # Crates from this repo that might become independent in the future.
-zksync_concurrency    = { path = "libs/concurrency" }
-zksync_protobuf       = { path = "libs/protobuf" }
-zksync_protobuf_build = { path = "libs/protobuf_build" }
+zksync_concurrency    = { version = "=0.9.0", path = "libs/concurrency" }
+zksync_protobuf       = { version = "=0.9.0", path = "libs/protobuf" }
+zksync_protobuf_build = { version = "=0.9.0", path = "libs/protobuf_build" }
 
 # Crates from Matter Labs.
 vise          = "0.2.0"


### PR DESCRIPTION
## What ❔

* [x] Fix workspace path in publish crates
* [x] Return back `version` in Cargo.toml. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix crates.io publishing and builds.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
