### PR TITLE
ci: fix sccache action issues

### DIFF
--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -33,7 +33,7 @@ jobs:
   compatibility:
     runs-on: [ubuntu-24.04-github-hosted-16core]
     steps:
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.9
 
       # before
       - uses: actions/checkout@v4

--- a/.github/workflows/protobuf_conformance.yaml
+++ b/.github/workflows/protobuf_conformance.yaml
@@ -27,7 +27,7 @@ jobs:
           repository: "protocolbuffers/protobuf"
           ref: "a47a7bdc8d023467f4f0586c393597af727e1d9e"
           path: "protobuf"
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: build test
         run: cargo build -p zksync_protobuf --example conformance_test
         working-directory: "this/node"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: install nextest
         uses: baptiste0928/cargo-install@v2
         with:


### PR DESCRIPTION
## What ❔

* [x] Update sccache action to 0.0.9

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

CI in `main` started to fail:
https://github.com/matter-labs/era-consensus/actions/runs/14491488072/job/40648760180

```
error: process didn't exit successfully: `sccache /home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc -vV` (exit status: 2)
--- stderr
sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}

Context:
   uri: https://acghubeus1.actions.githubusercontent.com/AR5OeawW1dLOZh598L08yg89UThkS6Kw5HMLgSddbyh2j1ZTcA/_apis/artifactcache/cache?keys=sccache/.sccache_check&version=sccache-v0.10.0
   response: Parts { status: 422, version: HTTP/1.1, headers: {"content-length": "426", "content-type": "application/json; charset=utf-8", "date": "Wed, 16 Apr 2025 11:23:13 GMT", "server": "Kestrel", "cache-control": "no-store,no-cache", "pragma": "no-cache", "strict-transport-security": "max-age=2592000", "x-tfs-processid": "34a7a3b0-dc55-44aa-abb8-985bfd029530", "activityid": "b94e1d12-d401-4598-a8ac-ab2bc4fc6ef3", "x-tfs-session": "b94e1d12-d401-4598-a8ac-ab2bc4fc6ef3", "x-vss-e2eid": "b94e1d12-d401-4598-a8ac-ab2bc4fc6ef3", "x-vss-senderdeploymentid": "e3de3c8c-fa12-3[18](https://github.com/matter-labs/era-consensus/actions/runs/14491488072/job/40648760180#step:5:19)e-3301-e1d3e326b2e8", "x-frame-options": "SAMEORIGIN"} }
   service: ghac
   path: .sccache_check
   range: 0-
```

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
