### PR TITLE
fix: Allow port reuse in production

### DIFF
--- a/node/components/executor/src/lib.rs
+++ b/node/components/executor/src/lib.rs
@@ -160,7 +160,7 @@ impl Executor {
                 network_recv,
             )?;
             net.register_metrics();
-            s.spawn(async { runner.run(ctx).await.context("Network stopped") });
+            s.spawn(async { runner.run(ctx, true).await.context("Network stopped") });
 
             if let Some(cfg) = self.config.debug_page.clone() {
                 s.spawn(async {

--- a/node/components/network/src/consensus/tests.rs
+++ b/node/components/network/src/consensus/tests.rs
@@ -161,7 +161,10 @@ async fn test_genesis_mismatch() {
     let cfgs = testonly::new_configs(rng, &setup, /*gossip_peers=*/ 0);
 
     scope::run!(ctx, |ctx, s| async {
-        let mut listener = cfgs[1].server_addr.bind().context("server_addr.bind()")?;
+        let mut listener = cfgs[1]
+            .server_addr
+            .bind(false)
+            .context("server_addr.bind()")?;
 
         tracing::trace!("Start one node, we will simulate the other one.");
         let engine = TestEngine::new(ctx, &setup).await;

--- a/node/components/network/src/gossip/tests/mod.rs
+++ b/node/components/network/src/gossip/tests/mod.rs
@@ -296,7 +296,10 @@ async fn test_genesis_mismatch() {
     let cfgs = testonly::new_configs(rng, &setup, 1);
 
     scope::run!(ctx, |ctx, s| async {
-        let mut listener = cfgs[1].server_addr.bind().context("server_addr.bind()")?;
+        let mut listener = cfgs[1]
+            .server_addr
+            .bind(false)
+            .context("server_addr.bind()")?;
 
         tracing::trace!("Start one node, we will simulate the other one.");
         let engine = TestEngine::new(ctx, &setup).await;

--- a/node/components/network/src/lib.rs
+++ b/node/components/network/src/lib.rs
@@ -101,7 +101,7 @@ impl Network {
 
 impl Runner {
     /// Runs the network component.
-    pub async fn run(mut self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
+    pub async fn run(mut self, ctx: &ctx::Ctx, in_production: bool) -> anyhow::Result<()> {
         // In order to satisfy the borrow checker, this validator schedule needs to live as long as the runner.
         let validators_opt = self.net.gossip.validator_schedule()?;
 
@@ -111,7 +111,7 @@ impl Runner {
                 .gossip
                 .cfg
                 .server_addr
-                .bind()
+                .bind(in_production)
                 .context("server_addr.bind()")?;
 
             // Spawn task to check when this instance of the network component is shutting down.

--- a/node/components/network/src/testonly.rs
+++ b/node/components/network/src/testonly.rs
@@ -168,7 +168,7 @@ impl InstanceRunner {
     /// Runs the instance background processes.
     pub async fn run(mut self, ctx: &ctx::Ctx) -> anyhow::Result<()> {
         scope::run!(ctx, |ctx, s| async {
-            s.spawn_bg(self.net_runner.run(ctx));
+            s.spawn_bg(self.net_runner.run(ctx, false));
             let _ = self.terminate.recv(ctx).await;
             Ok(())
         })

--- a/node/libs/concurrency/src/net/tcp/testonly.rs
+++ b/node/libs/concurrency/src/net/tcp/testonly.rs
@@ -28,7 +28,7 @@ pub fn reserve_listener() -> ListenerAddr {
 pub async fn pipe(ctx: &ctx::Ctx) -> (Stream, Stream) {
     let addr = reserve_listener();
     scope::run!(ctx, |ctx, s| async {
-        let mut listener = addr.bind()?;
+        let mut listener = addr.bind(false)?;
         let s1 = s.spawn(async { connect(ctx, *addr).await.unwrap() });
         let s2 = accept(ctx, &mut listener).await.unwrap()?;
         Ok((s1.join(ctx).await.unwrap(), s2))


### PR DESCRIPTION
## What ❔

In production validator set rotation is not working because we don't allow two instances of network to use the same TCP port. This enables it (only for production).