### PR TITLE
refactor: Make fetch schedule rate configurable

### DIFF
--- a/node/components/network/src/gossip/tests/fetch_blocks.rs
+++ b/node/components/network/src/gossip/tests/fetch_blocks.rs
@@ -2,7 +2,7 @@
 use assert_matches::assert_matches;
 use rand::Rng as _;
 use tracing::Instrument as _;
-use zksync_concurrency::{ctx, limiter, scope, testonly::abort_on_panic};
+use zksync_concurrency::{ctx, limiter, scope, testonly::abort_on_panic, time};
 use zksync_consensus_engine::{
     testonly::{in_memory, TestEngine},
     BlockStoreState, EngineInterface as _, EngineManager,
@@ -347,7 +347,8 @@ async fn test_announce_truncated_block_range() {
     scope::run!(ctx, |ctx, s| async {
         // Build a custom persistent store, so that we can tweak it later.
         let mut engine = in_memory::Engine::new_random(&setup, setup.first_block());
-        let (manager, runner) = EngineManager::new(ctx, Box::new(engine.clone())).await?;
+        let (manager, runner) =
+            EngineManager::new(ctx, Box::new(engine.clone()), time::Duration::seconds(1)).await?;
         s.spawn_bg(runner.run(ctx));
         let (_node, runner) = crate::testonly::Instance::new(cfg.clone(), manager);
         s.spawn_bg(runner.run(ctx).instrument(tracing::trace_span!("node")));

--- a/node/components/network/src/gossip/tests/syncing.rs
+++ b/node/components/network/src/gossip/tests/syncing.rs
@@ -337,7 +337,8 @@ async fn test_sidechannel_sync() {
             // Build a custom persistent store, so that we can tweak it later.
             let engine = in_memory::Engine::new_random(&setup, setup.first_block());
             engines.push(engine.clone());
-            let (manager, runner) = EngineManager::new(ctx, Box::new(engine)).await?;
+            let (manager, runner) =
+                EngineManager::new(ctx, Box::new(engine), time::Duration::seconds(1)).await?;
             s.spawn_bg(runner.run(ctx));
             let (node, runner) = testonly::Instance::new(cfg, manager);
             s.spawn_bg(runner.run(ctx).instrument(tracing::trace_span!("node", i)));

--- a/node/libs/engine/src/testonly/mod.rs
+++ b/node/libs/engine/src/testonly/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use in_memory::PayloadManager;
 use rand::{distributions::Standard, prelude::Distribution, Rng};
-use zksync_concurrency::ctx;
+use zksync_concurrency::{ctx, time};
 use zksync_consensus_roles::{validator, validator::testonly::Setup};
 
 use crate::{BlockStoreState, EngineInterface, EngineManager, EngineManagerRunner, Last};
@@ -52,9 +52,10 @@ impl TestEngine {
         first: validator::BlockNumber,
     ) -> Self {
         let im_engine = in_memory::Engine::new_random(setup, first);
-        let (engine, runner) = EngineManager::new(ctx, Box::new(im_engine.clone()))
-            .await
-            .unwrap();
+        let (engine, runner) =
+            EngineManager::new(ctx, Box::new(im_engine.clone()), time::Duration::seconds(1))
+                .await
+                .unwrap();
         Self {
             manager: engine,
             runner,
@@ -69,9 +70,10 @@ impl TestEngine {
         payload_manager: PayloadManager,
     ) -> Self {
         let im_engine = in_memory::Engine::new(setup, setup.first_block(), payload_manager);
-        let (engine, runner) = EngineManager::new(ctx, Box::new(im_engine.clone()))
-            .await
-            .unwrap();
+        let (engine, runner) =
+            EngineManager::new(ctx, Box::new(im_engine.clone()), time::Duration::seconds(1))
+                .await
+                .unwrap();
         Self {
             manager: engine,
             runner,
@@ -85,9 +87,10 @@ impl TestEngine {
         assert!(setup.genesis.validators_schedule.is_none());
 
         let im_engine = in_memory::Engine::new_dynamic_schedule(setup, setup.first_block(), n);
-        let (engine, runner) = EngineManager::new(ctx, Box::new(im_engine.clone()))
-            .await
-            .unwrap();
+        let (engine, runner) =
+            EngineManager::new(ctx, Box::new(im_engine.clone()), time::Duration::seconds(1))
+                .await
+                .unwrap();
         Self {
             manager: engine,
             runner,

--- a/node/tools/src/bin/localnet_config.rs
+++ b/node/tools/src/bin/localnet_config.rs
@@ -84,6 +84,7 @@ fn main() -> anyhow::Result<()> {
             gossip_static_inbound: HashSet::default(),
             gossip_static_outbound: HashMap::default(),
             debug_page: None,
+            fetch_schedule_interval: time::Duration::seconds(30),
         })
         .collect();
 

--- a/node/tools/src/config.rs
+++ b/node/tools/src/config.rs
@@ -83,6 +83,8 @@ pub struct App {
     pub gossip_static_outbound: HashMap<node::PublicKey, net::Host>,
 
     pub debug_page: Option<DebugPage>,
+
+    pub fetch_schedule_interval: time::Duration,
 }
 
 impl ProtoFmt for DebugPage {
@@ -146,6 +148,8 @@ impl ProtoFmt for App {
             gossip_static_inbound,
             gossip_static_outbound,
             debug_page: read_optional(&r.debug_page).context("debug_page")?,
+            fetch_schedule_interval: read_required(&r.fetch_schedule_interval)
+                .context("fetch_schedule_interval")?,
         })
     }
 
@@ -179,6 +183,7 @@ impl ProtoFmt for App {
                 })
                 .collect(),
             debug_page: self.debug_page.as_ref().map(|x| x.build()),
+            fetch_schedule_interval: Some(self.fetch_schedule_interval.build()),
         }
     }
 }
@@ -218,7 +223,8 @@ impl Configs {
                 200,
             ))
         };
-        let (engine_manager, runner) = EngineManager::new(ctx, engine).await?;
+        let (engine_manager, runner) =
+            EngineManager::new(ctx, engine, self.app.fetch_schedule_interval).await?;
 
         let e = executor::Executor {
             config: executor::Config {

--- a/node/tools/src/proto/mod.proto
+++ b/node/tools/src/proto/mod.proto
@@ -86,7 +86,7 @@ message AppConfig {
   optional uint64 max_payload_size = 5; // required; bytes
 
   // The duration of the view timeout.
-  optional std.Duration view_timeout = 19; // required; milliseconds
+  optional std.Duration view_timeout = 19; // required;
 
   // Validator secret key.
   optional string validator_secret_key = 10; // optional; ValidatorSecretKey
@@ -107,4 +107,7 @@ message AppConfig {
 
   // Debug page configuration.
   optional DebugPageConfig debug_page = 18; // optional
+
+  // The interval at which we fetch the pending validator schedule.
+  optional std.Duration fetch_schedule_interval = 20; // required;
 }

--- a/node/tools/src/tests.rs
+++ b/node/tools/src/tests.rs
@@ -29,6 +29,7 @@ impl Distribution<config::App> for EncodeDist {
                 .map(|_| (rng.gen(), self.sample(rng)))
                 .collect(),
             debug_page: self.sample(rng),
+            fetch_schedule_interval: self.sample(rng),
         }
     }
 }


### PR DESCRIPTION
## What ❔

Instead of hardcoding the rate at which we try to fetch pending schedules from the consensus registry, we just let it be configurable.
