### PR TITLE
feat: fix debug page port reuse

### DIFF
--- a/node/components/executor/src/lib.rs
+++ b/node/components/executor/src/lib.rs
@@ -169,7 +169,7 @@ impl Executor {
             if let Some(cfg) = self.config.debug_page.clone() {
                 s.spawn(async {
                     network::debug_page::Server::new(cfg, net)
-                        .run(ctx)
+                        .run(ctx, true)
                         .await
                         .context("Debug page server stopped")
                 });


### PR DESCRIPTION
## What ❔

Debug server was being stopped for port reuse. This allows port reuse but it's only a quick solution as it won't let us see the debug page properly while we have several network instances running in parallel.
